### PR TITLE
Json approval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
 			<version>1.3</version>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>

--- a/src/main/java/com/shazam/shazamcrest/FieldsIgnorer.java
+++ b/src/main/java/com/shazam/shazamcrest/FieldsIgnorer.java
@@ -1,10 +1,10 @@
 /*
  * Copyright 2013 Shazam Entertainment Limited
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 package com.shazam.shazamcrest;
@@ -34,11 +34,11 @@ import com.google.gson.JsonParser;
  */
 public class FieldsIgnorer {
 	public static final String MARKER = "!_TO_BE_SORTED_!";
-	
+
 	public static JsonElement findPaths(Gson gson, Object object, Set<String> pathsToFind) {
 		JsonParser jsonParser = new JsonParser();
 		JsonElement jsonElement = jsonParser.parse(gson.toJson(object));
-		
+
 		JsonElement filteredJson = findPaths(jsonElement, pathsToFind);
 		if (object != null && (Set.class.isAssignableFrom(object.getClass()) || Map.class.isAssignableFrom(object.getClass()))) {
 			return sortArray(filteredJson);
@@ -46,11 +46,11 @@ public class FieldsIgnorer {
 		return filteredJson;
 	}
 
-	private static JsonElement findPaths(JsonElement jsonElement, Set<String> pathsToFind) {
+	public static JsonElement findPaths(JsonElement jsonElement, Set<String> pathsToFind) {
 		if (pathsToFind.isEmpty()) {
 			return jsonElement;
 		}
-		
+
 		String pathToFind = headOf(pathsToFind);
 		List<String> pathSegments = asList(pathToFind.split(Pattern.quote(".")));
 		try {
@@ -69,7 +69,7 @@ public class FieldsIgnorer {
 
 	private static void findPath(JsonElement jsonElement, String pathToFind, final List<String> pathSegments) {
 		String field = headOf(pathSegments);
-		
+
 		if (jsonElement.isJsonArray()) {
 			Iterator<JsonElement> iterator = jsonElement.getAsJsonArray().iterator();
 			while (iterator.hasNext()) {
@@ -91,7 +91,7 @@ public class FieldsIgnorer {
 					}
 					List<String> tail = pathSegments.subList(1, pathSegments.size());
 					findPath(child, pathToFind, tail);
-					
+
 					child = sortArray(child);
 					jsonElement.getAsJsonObject().add(MARKER + field, child);
 				} else {
@@ -101,7 +101,7 @@ public class FieldsIgnorer {
 			}
 		}
 	}
-	
+
 	private static JsonElement sortArray(JsonElement jsonElement) {
 		TreeSet<JsonElement> orderedSet = newTreeSet(new Comparator<JsonElement>() {
 			@Override
@@ -126,13 +126,13 @@ public class FieldsIgnorer {
 			jsonElement.getAsJsonObject().remove(MARKER + getLastSegmentOf(pathToIgnore));
 		}
 	}
-	
+
 	private static String getLastSegmentOf(String fieldPath) {
 		String[] paths = fieldPath.split(Pattern.quote("."));
 		if (paths.length == 0) {
 			return fieldPath;
 		}
-		
+
 		return paths[max(0, paths.length-1)];
 	}
 

--- a/src/main/java/com/shazam/shazamcrest/matcher/CustomisableMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/CustomisableMatcher.java
@@ -47,14 +47,23 @@ public interface CustomisableMatcher<T> extends Matcher<T> {
 	 */
 	<V> CustomisableMatcher<T> with(String fieldPath, Matcher<V> matcher);
 
-	/**
-	 * Specify the pattern of field names to ignore. Any bean property with a name that
-	 * matches the supplied pattern will be ignored.
-	 * Example:
-	 * <pre>assertThat(myBean, sameBeanAs(myResultBean).ignoring(is("mutationdate")).ignoring(containsString("version")))</pre>
-	 * 
-	 * @param pattern the Hamcrest matcher used to match field names.
-	 * @return the instance of the matcher
-	 */
+    /**
+     * Specify a custom configuration for the Gson, for example, providing additional TypeAdapters.
+     *
+     * @param configuration {@link GsonConfiguration} object, containing TypeAdapterFactories, TypeAdapters and
+     * TypeHierarchyAdapters.
+     * @return the instance of the matcher
+     */
+    <V> CustomisableMatcher<T> withGsonConfiguration(GsonConfiguration configuration);
+
+    /**
+     * Specify the pattern of field names to ignore. Any bean property with a name that
+     * matches the supplied pattern will be ignored.
+     * Example:
+     * <pre>assertThat(myBean, sameBeanAs(myResultBean).ignoring(is("mutationdate")).ignoring(containsString("version")))</pre>
+     *
+     * @param pattern the Hamcrest matcher used to match field names.
+     * @return the instance of the matcher
+     */
     CustomisableMatcher<T> ignoring(Matcher<String> fieldNamePattern);
 }

--- a/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -41,9 +41,9 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 	private final Map<String, Matcher<?>> customMatchers = new HashMap<String, Matcher<?>>();
 	protected final List<Class<?>> typesToIgnore = new ArrayList<Class<?>>();
 	protected final List<Matcher<String>> patternsToIgnore = new ArrayList<Matcher<String>>();
-    protected final Set<Class<?>> circularReferenceTypes = new HashSet<Class<?>>();
-    protected final T expected;
-    private GsonConfiguration configuration;
+  protected final Set<Class<?>> circularReferenceTypes = new HashSet<Class<?>>();
+  protected final T expected;
+  private GsonConfiguration configuration;
 
     public DiagnosingCustomisableMatcher(T expected) {
         this.expected = expected;

--- a/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -1,10 +1,10 @@
 /*
  * Copyright 2013 Shazam Entertainment Limited
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 package com.shazam.shazamcrest.matcher;
@@ -42,15 +42,16 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 	protected final List<Class<?>> typesToIgnore = new ArrayList<Class<?>>();
 	protected final List<Matcher<String>> patternsToIgnore = new ArrayList<Matcher<String>>();
     protected final Set<Class<?>> circularReferenceTypes = new HashSet<Class<?>>();
-	protected final T expected;
+    protected final T expected;
+    private GsonConfiguration configuration;
 
     public DiagnosingCustomisableMatcher(T expected) {
         this.expected = expected;
     }
 
-	@Override
+    @Override
 	public void describeTo(Description description) {
-		Gson gson = gson(typesToIgnore, patternsToIgnore, circularReferenceTypes);
+		Gson gson = gson(typesToIgnore, patternsToIgnore, circularReferenceTypes, configuration);
 		description.appendText(filterJson(gson, expected));
 		for (String fieldPath : customMatchers.keySet()) {
 			description.appendText("\nand ")
@@ -63,12 +64,12 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 	protected boolean matches(Object actual, Description mismatchDescription) {
         circularReferenceTypes.addAll(getClassesWithCircularReferences(actual));
         circularReferenceTypes.addAll(getClassesWithCircularReferences(expected));
-		Gson gson = gson(typesToIgnore, patternsToIgnore, circularReferenceTypes);
-		
-		if (!areCustomMatchersMatching(actual, mismatchDescription, gson)) {
-			return false;
-		}
-		
+        Gson gson = gson(typesToIgnore, patternsToIgnore, circularReferenceTypes, configuration);
+
+    		if (!areCustomMatchersMatching(actual, mismatchDescription, gson)) {
+    			return false;
+    		}
+
 		String expectedJson = filterJson(gson, expected);
 
 		if (actual == null) {
@@ -86,7 +87,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 			Object object = actual == null ? null : findBeanAt(entry.getKey(), actual);
 			customMatching.put(object, customMatchers.get(entry.getKey()));
 		}
-		
+
 		for (Entry<Object, Matcher<?>> entry : customMatching.entrySet()) {
 			Matcher<?> matcher = entry.getValue();
 			Object object = entry.getKey();
@@ -111,7 +112,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 		typesToIgnore.add(clazz);
 		return this;
 	}
-	
+
 	@Override
 	public CustomisableMatcher<T> ignoring(Matcher<String> fieldNamePattern) {
 	    patternsToIgnore.add(fieldNamePattern);
@@ -123,6 +124,13 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 		customMatchers.put(fieldPath, matcher);
 		return this;
 	}
+
+    @Override
+    public CustomisableMatcher<T> withGsonConfiguration(final GsonConfiguration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
 
 	protected boolean appendMismatchDescription(Description mismatchDescription, String expectedJson, String actualJson, String message) {
 		if (mismatchDescription instanceof ComparisonDescription) {
@@ -154,7 +162,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 			mismatchDescription.appendText("\n" + gson.toJson(actual));
 		}
 	}
-	
+
 	private void appendFieldPath(Matcher<?> matcher, Description mismatchDescription) {
 		for (Entry<String, Matcher<?>> entry : customMatchers.entrySet()) {
 			if (entry.getValue().equals(matcher)) {
@@ -171,7 +179,7 @@ class DiagnosingCustomisableMatcher<T> extends DiagnosingMatcher<T> implements C
 
 		return removeSetMarker(gson.toJson(filteredJson));
 	}
-	
+
 	private String removeSetMarker(String json) {
 		return json.replaceAll(MARKER, "");
 	}

--- a/src/main/java/com/shazam/shazamcrest/matcher/GsonConfiguration.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/GsonConfiguration.java
@@ -1,0 +1,56 @@
+package com.shazam.shazamcrest.matcher;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.TypeAdapterFactory;
+
+/**
+ * Configuration file for {@link GsonProvider}.
+ * @author Andras_Gyuro
+ *
+ */
+public class GsonConfiguration {
+
+    private List<TypeAdapterFactory> typeAdapterFactories = new ArrayList<TypeAdapterFactory>();
+    private Map<Type, List<Object>> typeAdapters = new HashMap<Type, List<Object>>();
+    private Map<Class<?>, List<Object>> typeHierarchyAdapter = new HashMap<Class<?>, List<Object>>();
+
+    public void addTypeAdapterFactory(final TypeAdapterFactory factory) {
+        typeAdapterFactories.add(factory);
+    }
+
+    public void addTypeAdapter(final Type key, final Object value) {
+        if (typeAdapters.get(key) == null) {
+            typeAdapters.put(key, new ArrayList<Object>());
+            typeAdapters.get(key).add(value);
+        } else {
+            typeAdapters.get(key).add(value);
+        }
+    }
+
+    public void addTypeHierarchyAdapter(final Class<?> key, final Object value) {
+        if (typeHierarchyAdapter.get(key) == null) {
+            typeHierarchyAdapter.put(key, new ArrayList<Object>());
+            typeHierarchyAdapter.get(key).add(value);
+        } else {
+            typeHierarchyAdapter.get(key).add(value);
+        }
+    }
+
+    public List<TypeAdapterFactory> getTypeAdapterFactories() {
+        return typeAdapterFactories;
+    }
+
+    public Map<Type, List<Object>> getTypeAdapters() {
+        return typeAdapters;
+    }
+
+    public Map<Class<?>, List<Object>> getTypeHierarchyAdapter() {
+        return typeHierarchyAdapter;
+    }
+
+}

--- a/src/main/java/com/shazam/shazamcrest/matcher/GsonProvider.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/GsonProvider.java
@@ -1,10 +1,10 @@
 /*
  * Copyright 2013 Shazam Entertainment Limited
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 package com.shazam.shazamcrest.matcher;
@@ -35,6 +35,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapterFactory;
 import com.google.gson.graph.GraphAdapterBuilder;
 
 import org.hamcrest.Matcher;
@@ -55,29 +56,93 @@ class GsonProvider {
      */
     public static Gson gson(final List<Class<?>> typesToIgnore, final List<Matcher<String>> fieldsToIgnore, Set<Class<?>> circularReferenceTypes) {
     	final GsonBuilder gsonBuilder = initGson();
-    	
+
         if (!circularReferenceTypes.isEmpty()) {
             registerCircularReferenceTypes(circularReferenceTypes, gsonBuilder);
         }
-        
+
         gsonBuilder.registerTypeAdapter(Optional.class, new OptionalSerializer());
 
         registerSetSerialisation(gsonBuilder);
-        
+
         registerMapSerialisation(gsonBuilder);
-        
+
         markSetAndMapFields(gsonBuilder);
-        
+
         registerExclusionStrategies(gsonBuilder, typesToIgnore, fieldsToIgnore);
-        
+
+
         return gsonBuilder.create();
     }
-    
+
+    /**
+     * Returns a {@link Gson} instance containing {@link ExclusionStrategy} based on the object types to ignore during
+     * serialisation.
+     *
+     * @param typesToIgnore the object types to exclude from serialisation
+     * @param circularReferenceTypes cater for circular referenced objects
+     * @param additionalConfig provides additional gson configuration
+     * @return an instance of {@link Gson}
+     */
+    public static Gson gson(final List<Class<?>> typesToIgnore, final List<Matcher<String>> fieldsToIgnore,
+            final Set<Class<?>> circularReferenceTypes, final GsonConfiguration additionalConfig) {
+        final GsonBuilder gsonBuilder = initGson();
+
+        defaultGsonConfiguration(gsonBuilder, typesToIgnore, fieldsToIgnore, circularReferenceTypes);
+        if (additionalConfig != null) {
+            additionalConfiguration(additionalConfig, gsonBuilder);
+        }
+
+        return gsonBuilder.create();
+    }
+
+    private static void defaultGsonConfiguration(final GsonBuilder gsonBuilder, final List<Class<?>> typesToIgnore,
+            final List<Matcher<String>> fieldsToIgnore, final Set<Class<?>> circularReferenceTypes) {
+
+        if (!circularReferenceTypes.isEmpty()) {
+            registerCircularReferenceTypes(circularReferenceTypes, gsonBuilder);
+        }
+
+        gsonBuilder.registerTypeAdapter(Optional.class, new OptionalSerializer());
+
+        registerSetSerialisation(gsonBuilder);
+
+        registerMapSerialisation(gsonBuilder);
+
+        markSetAndMapFields(gsonBuilder);
+
+        registerExclusionStrategies(gsonBuilder, typesToIgnore, fieldsToIgnore);
+    }
+
+    private static void additionalConfiguration(final GsonConfiguration additionalConfig, final GsonBuilder gsonBuilder) {
+        for (TypeAdapterFactory factory : additionalConfig.getTypeAdapterFactories()) {
+            gsonBuilder.registerTypeAdapterFactory(factory);
+        }
+        Map<Type, List<Object>> typeAdapterMap = additionalConfig.getTypeAdapters();
+        for (Type type : typeAdapterMap.keySet()) {
+            if (typeAdapterMap.get(type) != null) {
+                for (Object o : typeAdapterMap.get(type)) {
+                    gsonBuilder.registerTypeAdapter(type, o);
+
+                }
+            }
+        }
+        Map<Class<?>, List<Object>> hierarchyTypeAdapterMap = additionalConfig.getTypeHierarchyAdapter();
+        for (Class<?> clazz : hierarchyTypeAdapterMap.keySet()) {
+            if (hierarchyTypeAdapterMap.get(clazz) != null) {
+                for (Object o : hierarchyTypeAdapterMap.get(clazz)) {
+                    gsonBuilder.registerTypeHierarchyAdapter(clazz, o);
+                }
+            }
+        }
+
+    }
+
 	private static void registerExclusionStrategies(GsonBuilder gsonBuilder, final List<Class<?>> typesToIgnore, final List<Matcher<String>> fieldsToIgnore) {
 		if (typesToIgnore.isEmpty() && fieldsToIgnore.isEmpty()) {
 			return;
 		}
-		
+
 		gsonBuilder.setExclusionStrategies(new ExclusionStrategy() {
             @Override
             public boolean shouldSkipField(FieldAttributes f) {
@@ -88,7 +153,7 @@ class GsonProvider {
                 }
                 return false;
             }
-            
+
             @Override
             public boolean shouldSkipClass(Class<?> clazz) {
                 return (typesToIgnore.contains(clazz));
@@ -113,7 +178,7 @@ class GsonProvider {
 			@Override
 			public JsonElement serialize(Map map, Type type, JsonSerializationContext context) {
 				Gson gson = gsonBuilder.create();
-				
+
         		ArrayListMultimap<String, Object> objects = mapObjectsByTheirJsonRepresentation(map, gson);
         		return arrayOfObjectsOrderedByTheirJsonRepresentation(gson, objects, map);
 			}
@@ -139,7 +204,7 @@ class GsonProvider {
 		}
 		graphAdapterBuilder.registerOn(gsonBuilder);
 	}
-    
+
     @SuppressWarnings("unchecked")
 	private static Set<Object> orderSetByElementsJsonRepresentation(Set set, final Gson gson) {
 		Set<Object> objects = newTreeSet(new Comparator<Object>() {
@@ -151,7 +216,7 @@ class GsonProvider {
 		objects.addAll(set);
 		return objects;
 	}
-    
+
     @SuppressWarnings("unchecked")
 	private static ArrayListMultimap<String, Object> mapObjectsByTheirJsonRepresentation(Map map, Gson gson) {
     	ArrayListMultimap<String, Object> objects = ArrayListMultimap.create();
@@ -168,7 +233,7 @@ class GsonProvider {
 		}
 		return array;
 	}
-	
+
 	private static JsonArray arrayOfObjectsOrderedByTheirJsonRepresentation(Gson gson, ArrayListMultimap<String, Object> objects, Map map) {
 		ImmutableList<String> sortedMapKeySet = Ordering.natural().immutableSortedCopy(objects.keySet());
 		JsonArray array = new JsonArray();
@@ -192,10 +257,10 @@ class GsonProvider {
 				}
 			}
 		}
-		
+
 		return array;
 	}
-	  
+
     private static boolean allKeysArePrimitiveOrStringOrEnum(ImmutableList<String> sortedMapKeySet, ArrayListMultimap<String, Object> objects) {
     	for (String jsonRepresentation : sortedMapKeySet) {
 			List<Object> mapKeys = objects.get(jsonRepresentation);
@@ -211,7 +276,7 @@ class GsonProvider {
 	private static GsonBuilder initGson() {
 		return new GsonBuilder().setPrettyPrinting();
 	}
-	
+
     private static class OptionalSerializer<T> implements JsonSerializer<Optional<T>> {
 
         @Override

--- a/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcher.java
@@ -234,25 +234,24 @@ public class JsonMatcher<T> extends DiagnosingMatcher<T> implements Customisable
 			throw new IllegalStateException(
 					String.format("Exception while initializing expected from file: %s", approvedFile.toString()), e);
 		}
-
 	}
 
 	private String readFile(File file) throws IOException {
-    BufferedReader br = new BufferedReader(new FileReader(file));
-    try {
-        StringBuilder sb = new StringBuilder();
-        String line = br.readLine();
+		BufferedReader br = new BufferedReader(new FileReader(file));
+		try {
+		    StringBuilder sb = new StringBuilder();
+		    String line = br.readLine();
 
-        while (line != null) {
-            sb.append(line);
-            sb.append("\n");
-            line = br.readLine();
-        }
-        return sb.toString();
-    } finally {
-        br.close();
-    }
-}
+		    while (line != null) {
+		        sb.append(line);
+		        sb.append("\n");
+		        line = br.readLine();
+		    }
+		    return sb.toString();
+		} finally {
+		    br.close();
+		}
+	}
 
 	private String filterJson(final Gson gson, final JsonElement jsonElement) {
 		Set<String> set = new HashSet<String>();

--- a/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcher.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcher.java
@@ -1,0 +1,379 @@
+package com.shazam.shazamcrest.matcher;
+
+import static com.shazam.shazamcrest.BeanFinder.findBeanAt;
+import static com.shazam.shazamcrest.CyclicReferenceDetector.getClassesWithCircularReferences;
+import static com.shazam.shazamcrest.FieldsIgnorer.MARKER;
+import static com.shazam.shazamcrest.FieldsIgnorer.findPaths;
+import static com.shazam.shazamcrest.matcher.JsonMatcherUtils.SEPARATOR;
+import static com.shazam.shazamcrest.matcher.JsonMatcherUtils.createNotApproved;
+import static com.shazam.shazamcrest.matcher.JsonMatcherUtils.getApproved;
+import static com.shazam.shazamcrest.matcher.JsonMatcherUtils.getCallerTestClassName;
+import static com.shazam.shazamcrest.matcher.JsonMatcherUtils.getCallerTestClassPath;
+import static com.shazam.shazamcrest.matcher.JsonMatcherUtils.getCallerTestMethodName;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matcher;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.google.common.base.Charsets;
+import com.google.common.hash.Hashing;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.shazam.shazamcrest.ComparisonDescription;
+
+/**
+ * <p>
+ * Matcher for asserting expected DTOs. Searches for an approved JSON file in
+ * the same directory as the test file:
+ * <ul>
+ * 		<li>If found, the matcher will assert the contents of the JSON file to the actual object,
+ * which is serialized to a JSON String. </li>
+ * 		<li>If not found, a non-approved JSON file is created, that must be
+ * verified and renamed to "*-approved.json" by the developer. </li>
+ * </ul>
+ * The files and directories are hashed with SHA-1 algorithm by default to avoid too long file
+ * and path names.
+ * These are generated in the following way:
+ * <ul>
+ *   <li> the directory name is the first {@value #NUM_OF_HASH_CHARS} characters of the hashed <b>class name</b>. </li>
+ *   <li> the file name is the first {@value #NUM_OF_HASH_CHARS} characters of the hashed <b>test method name</b>. </li>
+ * </ul>
+ *
+ * This default behaviour can be overridden by using the {@link #withFileName(String)} for
+ * custom file name and {@link #withPathName(String)} for custom path.
+ * </p>
+ *
+ * @author Andras_Gyuro
+ *
+ */
+public class JsonMatcher<T> extends DiagnosingMatcher<T> implements CustomisableMatcher<T> {
+
+	private static final int NUM_OF_HASH_CHARS = 6;
+
+	private String pathName;
+	private String fileName;
+	private String customFileName;
+	private String fileNameWithPath;
+	private String uniqueId;
+	private String testClassName;
+	private String testMethodName;
+	private String testClassNameHash;
+
+	private final Map<String, Matcher<?>> customMatchers = new HashMap<String, Matcher<?>>();
+	private final List<Class<?>> typesToIgnore = new ArrayList<Class<?>>();
+	private final List<Matcher<String>> patternsToIgnore = new ArrayList<Matcher<String>>();
+	private final Set<Class<?>> circularReferenceTypes = new HashSet<Class<?>>();
+	private JsonElement expected;
+
+	private final Set<String> pathsToIgnore = new HashSet<String>();
+	private GsonConfiguration configuration;
+
+	@Override
+	public void describeTo(final Description description) {
+		Gson gson = GsonProvider.gson(typesToIgnore, patternsToIgnore, circularReferenceTypes, configuration);
+		description.appendText(filterJson(gson, expected));
+		for (String fieldPath : customMatchers.keySet()) {
+			description.appendText("\nand ").appendText(fieldPath).appendText(" ")
+					.appendDescriptionOf(customMatchers.get(fieldPath));
+		}
+	}
+
+	@Override
+	public JsonMatcher<T> ignoring(final String fieldPath) {
+		pathsToIgnore.add(fieldPath);
+		return this;
+	}
+
+	@Override
+	public JsonMatcher<T> ignoring(final Class<?> clazz) {
+		typesToIgnore.add(clazz);
+		return this;
+	}
+
+	@Override
+	public JsonMatcher<T> ignoring(final Matcher<String> fieldNamePattern) {
+		patternsToIgnore.add(fieldNamePattern);
+		return this;
+	}
+
+	@Override
+	public <V> JsonMatcher<T> with(final String fieldPath, final Matcher<V> matcher) {
+		throw new UnsupportedOperationException("JSON approval with custom matcher not yet supported!");
+	}
+
+	@Override
+	public JsonMatcher<T> withGsonConfiguration(final GsonConfiguration configuration) {
+		this.configuration = configuration;
+		return this;
+	}
+
+	/**
+	 * Concatenates a unique ID to the generated file name. Useful for test cases
+	 * containing multiple verifications.
+	 *
+	 * @param uniqueId
+	 *          a {@link String} object, that uniquely identifies the file.
+	 * @return current instance
+	 */
+	public JsonMatcher<T> withUniqueId(final String uniqueId) {
+		this.uniqueId = uniqueId;
+		return this;
+	}
+
+	/**
+	 * Sets the file name to the given parameter.
+	 *
+	 * @param customFileName
+	 *          a {@link String} object, which will be the base file name. The
+	 *          approved/not-approved identifier and file extension will still be
+	 *          concatenated to this.
+	 * @return current instance
+	 */
+	public JsonMatcher<T> withFileName(final String customFileName) {
+		this.customFileName = customFileName;
+		return this;
+	}
+
+	/**
+	 * Sets the file path to the given parameter.
+	 *
+	 * @param fileName
+	 *          a {@link String} object, which will be the file path.
+	 * @return current instance
+	 */
+	public JsonMatcher<T> withPathName(final String pathName) {
+		this.pathName = pathName;
+		return this;
+	}
+
+	@Override
+	protected boolean matches(final Object actual, final Description mismatchDescription) {
+		boolean matches = false;
+		circularReferenceTypes.addAll(getClassesWithCircularReferences(actual));
+		init();
+		Gson gson = GsonProvider.gson(typesToIgnore, patternsToIgnore, circularReferenceTypes, configuration);
+		createApprovedFileIfNotExists(actual, gson);
+		initExpectedFromFile();
+
+		if (areCustomMatchersMatching(actual, mismatchDescription, gson)) {
+
+			String expectedJson = filterJson(gson, expected);
+
+			JsonElement actualJsonElement = getAsJsonElement(gson, actual);
+
+			if (actual == null) {
+				matches = appendMismatchDescription(mismatchDescription, expectedJson, "null", "actual was null");
+			} else {
+				String actualJson = filterJson(gson, actualJsonElement);
+
+				matches = assertEquals(expectedJson, actualJson, mismatchDescription);
+			}
+		} else {
+			matches = false;
+		}
+		return matches;
+	}
+
+	private void init() {
+		testMethodName = getCallerTestMethodName();
+		testClassName = getCallerTestClassName();
+
+		if (customFileName == null || customFileName.trim().isEmpty()) {
+			fileName = hashFileName(testMethodName);
+		} else {
+			fileName = customFileName;
+		}
+		if (uniqueId != null) {
+			fileName += SEPARATOR + uniqueId;
+		}
+		if (pathName == null || pathName.trim().isEmpty()) {
+			testClassNameHash = hashFileName(testClassName);
+			pathName = getCallerTestClassPath() + File.separator + testClassNameHash;
+		}
+
+		fileNameWithPath = pathName + File.separator + fileName;
+	}
+
+	private String hashFileName(final String fileName) {
+		return Hashing.sha1().hashString(fileName, Charsets.UTF_8).toString().substring(0, NUM_OF_HASH_CHARS);
+	}
+
+	private JsonElement getAsJsonElement(final Gson gson, final Object object) {
+		JsonElement result;
+		if (object instanceof String) {
+			JsonParser jsonParser = new JsonParser();
+			result = jsonParser.parse((String) object);
+		} else {
+			result = gson.toJsonTree(object);
+		}
+		return result;
+
+	}
+
+	private void initExpectedFromFile() {
+		File approvedFile = getApproved(fileNameWithPath);
+
+		try {
+			String approvedJsonStr = readFile(approvedFile);
+			JsonParser jsonParser = new JsonParser();
+			expected = jsonParser.parse(approvedJsonStr);
+		} catch (IOException e) {
+			throw new IllegalStateException(
+					String.format("Exception while initializing expected from file: %s", approvedFile.toString()), e);
+		}
+
+	}
+
+	private String readFile(File file) throws IOException {
+    BufferedReader br = new BufferedReader(new FileReader(file));
+    try {
+        StringBuilder sb = new StringBuilder();
+        String line = br.readLine();
+
+        while (line != null) {
+            sb.append(line);
+            sb.append("\n");
+            line = br.readLine();
+        }
+        return sb.toString();
+    } finally {
+        br.close();
+    }
+}
+
+	private String filterJson(final Gson gson, final JsonElement jsonElement) {
+		Set<String> set = new HashSet<String>();
+		set.addAll(pathsToIgnore);
+
+		JsonElement filteredJson = findPaths(jsonElement, set);
+
+		return removeSetMarker(gson.toJson(filteredJson));
+	}
+
+	private boolean assertEquals(final String expectedJson, final String actualJson,
+			final Description mismatchDescription) {
+		try {
+			JSONAssert.assertEquals(expectedJson, actualJson, true);
+		} catch (AssertionError e) {
+			return appendMismatchDescription(mismatchDescription, expectedJson, actualJson, getAssertMessage(e));
+		} catch (JSONException e) {
+			return appendMismatchDescription(mismatchDescription, expectedJson, actualJson, getAssertMessage(e));
+		}
+
+		return true;
+	}
+
+	private String getAssertMessage(final Throwable t) {
+		String result;
+		if (testClassNameHash == null) {
+			result = "Expected file " + fileNameWithPath + "\n" + t.getMessage();
+		} else {
+			result = "Expected file " + testClassNameHash + File.separator + JsonMatcherUtils.getFullFileName(fileName, true)
+					+ "\n" + t.getMessage();
+		}
+		return result;
+	}
+
+	private String removeSetMarker(final String json) {
+		return json.replaceAll(MARKER, "");
+	}
+
+	private void createApprovedFileIfNotExists(final Object toApprove, final Gson gson) {
+		File approvedFile = getApproved(fileNameWithPath);
+
+		if (!approvedFile.exists()) {
+			try {
+				String approvedFileName = approvedFile.getName();
+				String content;
+				if (String.class.isInstance(toApprove)) {
+					JsonParser jsonParser = new JsonParser();
+					JsonElement toApproveJsonElement = jsonParser.parse(String.class.cast(toApprove));
+					content = removeSetMarker(gson.toJson(toApproveJsonElement));
+				} else {
+					content = removeSetMarker(gson.toJson(toApprove));
+				}
+				String createdFileName = createNotApproved(fileNameWithPath, content, testClassName + "." + testMethodName);
+				String message;
+				if (testClassNameHash == null) {
+					message = "Not approved file created '" + createdFileName
+							+ "', please verify it's contents and rename it to '" + approvedFileName + "'.";
+				} else {
+					message = "Not approved file created '" + testClassNameHash + File.separator + createdFileName
+							+ "', please verify it's contents and rename it to '" + approvedFileName + "'.";
+				}
+				fail(message);
+
+			} catch (IOException e) {
+				throw new IllegalStateException(
+						String.format("Exception while creating not approved file %s", toApprove.toString()), e);
+			}
+		}
+	}
+
+	private boolean appendMismatchDescription(final Description mismatchDescription, final String expectedJson,
+			final String actualJson, final String message) {
+		if (mismatchDescription instanceof ComparisonDescription) {
+			ComparisonDescription shazamMismatchDescription = (ComparisonDescription) mismatchDescription;
+			shazamMismatchDescription.setComparisonFailure(true);
+			shazamMismatchDescription.setExpected(expectedJson);
+			shazamMismatchDescription.setActual(actualJson);
+			shazamMismatchDescription.setDifferencesMessage(message);
+		}
+		mismatchDescription.appendText(message);
+		return false;
+	}
+
+	private boolean areCustomMatchersMatching(final Object actual, final Description mismatchDescription,
+			final Gson gson) {
+		boolean result = true;
+		Map<Object, Matcher<?>> customMatching = new HashMap<Object, Matcher<?>>();
+		for (Entry<String, Matcher<?>> entry : customMatchers.entrySet()) {
+			Object object = actual == null ? null : findBeanAt(entry.getKey(), actual);
+			customMatching.put(object, customMatchers.get(entry.getKey()));
+		}
+
+		for (Entry<Object, Matcher<?>> entry : customMatching.entrySet()) {
+			Matcher<?> matcher = entry.getValue();
+			Object object = entry.getKey();
+			if (!matcher.matches(object)) {
+				appendFieldPath(matcher, mismatchDescription);
+				matcher.describeMismatch(object, mismatchDescription);
+				appendFieldJsonSnippet(object, mismatchDescription, gson);
+				result = false;
+			}
+		}
+		return result;
+	}
+
+	private void appendFieldJsonSnippet(final Object actual, final Description mismatchDescription, final Gson gson) {
+		JsonElement jsonTree = gson.toJsonTree(actual);
+		if (!jsonTree.isJsonPrimitive() && !jsonTree.isJsonNull()) {
+			mismatchDescription.appendText("\n" + gson.toJson(actual));
+		}
+	}
+
+	private void appendFieldPath(final Matcher<?> matcher, final Description mismatchDescription) {
+		for (Entry<String, Matcher<?>> entry : customMatchers.entrySet()) {
+			if (entry.getValue().equals(matcher)) {
+				mismatchDescription.appendText(entry.getKey()).appendText(" ");
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcherUtils.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcherUtils.java
@@ -1,0 +1,136 @@
+package com.shazam.shazamcrest.matcher;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Utility class with methods for creating the JSON files for
+ * {@link JsonMatcher}.
+ *
+ * @author Andras_Gyuro
+ *
+ */
+public final class JsonMatcherUtils {
+
+	public static final Object SEPARATOR = "-";
+	private static final String SRC_TEST_JAVA_PATH = "src" + File.separator + "test" + File.separator + "java"
+			+ File.separator;
+	private static final String FILE_EXTENSION = ".json";
+	private static final String APPROVED_NAME_PART = "approved";
+	private static final String NOT_APPROVED_NAME_PART = "not-approved";
+
+	private JsonMatcherUtils() {
+	}
+
+	/**
+	 * Creates file with '-not-approved' suffix and .json extension and writes the
+	 * jsonObject in it.
+	 *
+	 * @param fileNameWithPath specifies the name of the file with full path (relative to project root)
+	 * @param jsonObject the file's content
+	 * @throws IOException exception thrown when failed to create the file
+	 */
+	public static String createNotApproved(final String fileNameWithPath, final String jsonObject, final String comment)
+			throws IOException {
+		File file = new File(getFullFileName(fileNameWithPath, false));
+		file.getParentFile().mkdirs();
+		FileWriter writer = new FileWriter(file);
+		writer.append("/*" + comment + "*/");
+		writer.append("\n");
+		writer.append(jsonObject);
+		writer.close();
+		return file.getName();
+	}
+
+	/**
+	 * Gets file with '-approved' suffix and .json extension and returns it.
+	 *
+	 * @param fileNameWithPath the name of the file with full path (relative to project root)
+	 * @return the {@link File} object
+	 */
+	public static File getApproved(final String fileNameWithPath) {
+		File file = new File(getFullFileName(fileNameWithPath, true));
+		return file;
+	}
+
+	/**
+	 * Returns the name of the test method, in which the call was originated from.
+	 *
+	 * @return test method name in String
+	 */
+	public static String getCallerTestMethodName() {
+		StackTraceElement testStackTraceElement = getTestStackTraceElement(Thread.currentThread().getStackTrace());
+		return testStackTraceElement != null ? testStackTraceElement.getMethodName() : null;
+	}
+
+	/**
+	 * Returns the name of the test class file which the call was originated from.
+	 *
+	 * @return test method's class name
+	 */
+	public static String getCallerTestClassName() {
+		StackTraceElement testStackTraceElement = getTestStackTraceElement(Thread.currentThread().getStackTrace());
+		return testStackTraceElement.getClassName();
+	}
+
+	/**
+	 * Returns the absolute path of the test class in which the call was originated from.
+	 *
+	 * @return test method name in String
+	 */
+	public static String getCallerTestClassPath() {
+		StackTraceElement testStackTraceElement = getTestStackTraceElement(Thread.currentThread().getStackTrace());
+		String fileName = testStackTraceElement.getFileName().substring(0,
+				testStackTraceElement.getFileName().lastIndexOf("."));
+		return SRC_TEST_JAVA_PATH + testStackTraceElement.getClassName().replace(".", File.separator).replace(fileName, "");
+	}
+
+	private static StackTraceElement getTestStackTraceElement(final StackTraceElement[] stackTrace) {
+		StackTraceElement result = null;
+		for (int i = 0; i < stackTrace.length; i++) {
+			StackTraceElement s = stackTrace[i];
+			if (isTestMethod(s)) {
+				result = s;
+				break;
+			}
+		}
+		return result;
+	}
+
+	private static boolean isTestMethod(final StackTraceElement element) {
+		boolean isTest;
+
+		String fullClassName = element.getClassName();
+		Class<?> clazz;
+		try {
+			clazz = Class.forName(fullClassName);
+			isTest = clazz.getMethod(element.getMethodName()).isAnnotationPresent(Test.class);
+
+		} catch (Throwable e) {
+			isTest = false;
+		}
+
+		return isTest;
+	}
+
+	public static String getFullFileName(final String fileName, final boolean approved) {
+		return getFileNameWithExtension(fileName, approved);
+	}
+
+	private static String getFileNameWithExtension(final String fileName, final boolean approved) {
+		StringBuilder stringBuilder = new StringBuilder();
+
+		stringBuilder.append(fileName);
+		stringBuilder.append(SEPARATOR);
+		if (approved) {
+			stringBuilder.append(APPROVED_NAME_PART);
+		} else {
+			stringBuilder.append(NOT_APPROVED_NAME_PART);
+		}
+		stringBuilder.append(FILE_EXTENSION);
+
+		return stringBuilder.toString();
+	}
+}

--- a/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcherUtils.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/JsonMatcherUtils.java
@@ -3,6 +3,8 @@ package com.shazam.shazamcrest.matcher;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+
 import org.junit.Test;
 
 /**
@@ -12,7 +14,7 @@ import org.junit.Test;
  * @author Andras_Gyuro
  *
  */
-public final class JsonMatcherUtils {
+public class JsonMatcherUtils {
 
 	public static final Object SEPARATOR = "-";
 	private static final String SRC_TEST_JAVA_PATH = "src" + File.separator + "test" + File.separator + "java"
@@ -20,9 +22,6 @@ public final class JsonMatcherUtils {
 	private static final String FILE_EXTENSION = ".json";
 	private static final String APPROVED_NAME_PART = "approved";
 	private static final String NOT_APPROVED_NAME_PART = "not-approved";
-
-	private JsonMatcherUtils() {
-	}
 
 	/**
 	 * Creates file with '-not-approved' suffix and .json extension and writes the
@@ -32,11 +31,11 @@ public final class JsonMatcherUtils {
 	 * @param jsonObject the file's content
 	 * @throws IOException exception thrown when failed to create the file
 	 */
-	public static String createNotApproved(final String fileNameWithPath, final String jsonObject, final String comment)
+	public String createNotApproved(final String fileNameWithPath, final String jsonObject, final String comment)
 			throws IOException {
 		File file = new File(getFullFileName(fileNameWithPath, false));
 		file.getParentFile().mkdirs();
-		FileWriter writer = new FileWriter(file);
+		Writer writer = new FileWriter(file);
 		writer.append("/*" + comment + "*/");
 		writer.append("\n");
 		writer.append(jsonObject);
@@ -50,7 +49,7 @@ public final class JsonMatcherUtils {
 	 * @param fileNameWithPath the name of the file with full path (relative to project root)
 	 * @return the {@link File} object
 	 */
-	public static File getApproved(final String fileNameWithPath) {
+	public File getApproved(final String fileNameWithPath) {
 		File file = new File(getFullFileName(fileNameWithPath, true));
 		return file;
 	}
@@ -60,7 +59,7 @@ public final class JsonMatcherUtils {
 	 *
 	 * @return test method name in String
 	 */
-	public static String getCallerTestMethodName() {
+	public String getCallerTestMethodName() {
 		StackTraceElement testStackTraceElement = getTestStackTraceElement(Thread.currentThread().getStackTrace());
 		return testStackTraceElement != null ? testStackTraceElement.getMethodName() : null;
 	}
@@ -70,7 +69,7 @@ public final class JsonMatcherUtils {
 	 *
 	 * @return test method's class name
 	 */
-	public static String getCallerTestClassName() {
+	public String getCallerTestClassName() {
 		StackTraceElement testStackTraceElement = getTestStackTraceElement(Thread.currentThread().getStackTrace());
 		return testStackTraceElement.getClassName();
 	}
@@ -80,14 +79,14 @@ public final class JsonMatcherUtils {
 	 *
 	 * @return test method name in String
 	 */
-	public static String getCallerTestClassPath() {
+	public String getCallerTestClassPath() {
 		StackTraceElement testStackTraceElement = getTestStackTraceElement(Thread.currentThread().getStackTrace());
 		String fileName = testStackTraceElement.getFileName().substring(0,
 				testStackTraceElement.getFileName().lastIndexOf("."));
 		return SRC_TEST_JAVA_PATH + testStackTraceElement.getClassName().replace(".", File.separator).replace(fileName, "");
 	}
 
-	private static StackTraceElement getTestStackTraceElement(final StackTraceElement[] stackTrace) {
+	private StackTraceElement getTestStackTraceElement(final StackTraceElement[] stackTrace) {
 		StackTraceElement result = null;
 		for (int i = 0; i < stackTrace.length; i++) {
 			StackTraceElement s = stackTrace[i];
@@ -99,7 +98,7 @@ public final class JsonMatcherUtils {
 		return result;
 	}
 
-	private static boolean isTestMethod(final StackTraceElement element) {
+	private boolean isTestMethod(final StackTraceElement element) {
 		boolean isTest;
 
 		String fullClassName = element.getClassName();
@@ -115,11 +114,11 @@ public final class JsonMatcherUtils {
 		return isTest;
 	}
 
-	public static String getFullFileName(final String fileName, final boolean approved) {
+	public String getFullFileName(final String fileName, final boolean approved) {
 		return getFileNameWithExtension(fileName, approved);
 	}
 
-	private static String getFileNameWithExtension(final String fileName, final boolean approved) {
+	private String getFileNameWithExtension(final String fileName, final boolean approved) {
 		StringBuilder stringBuilder = new StringBuilder();
 
 		stringBuilder.append(fileName);

--- a/src/main/java/com/shazam/shazamcrest/matcher/Matchers.java
+++ b/src/main/java/com/shazam/shazamcrest/matcher/Matchers.java
@@ -1,10 +1,10 @@
 /*
  * Copyright 2013 Shazam Entertainment Limited
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 package com.shazam.shazamcrest.matcher;
@@ -20,7 +20,7 @@ public class Matchers {
 	 * Returns a {@link NullMatcher} in case the expectation is null, a
 	 * {@link IsEqualMatcher} if it's a primitive, String or Enum
 	 * or a {@link DiagnosingCustomisableMatcher} otherwise.
-	 * 
+	 *
 	 * @param expected the expected bean to match against
 	 * @return an {@link CustomisableMatcher} instance
 	 */
@@ -28,11 +28,21 @@ public class Matchers {
 		if (expected == null) {
 			return new NullMatcher<T>(expected);
 		}
-		
+
 		if (isPrimitiveOrWrapper(expected.getClass()) || expected.getClass() == String.class || expected.getClass().isEnum()) {
 			return new IsEqualMatcher<T>(expected);
 		}
-		
+
 		return new DiagnosingCustomisableMatcher<T>(expected);
 	}
+
+  /**
+   * Returns a {@link JsonMatcher} for matching an object with a generated file.
+   *
+   * @return a new {@link JsonMatcher} instance
+   */
+  public static <T> JsonMatcher<T> sameJsonAsApproved() {
+      return new JsonMatcher<T>();
+  }
+
 }

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/10b21f-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/10b21f-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldThrowAssertionErrorWhenModelDiffersFromApprovedJson*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanLong": 5,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0,
+  "beanBoolean": false
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/1f01a2-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/1f01a2-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJsonWithGsonConfiguration*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanLong": "6 Long_variable",
+  "beanFloat": 3.0,
+  "beanDouble": 5.0,
+  "beanBoolean": true
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/2261c7-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/2261c7-approved.json
@@ -1,0 +1,9 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldThrowAssertionErrorWhenModelDiffersFromApprovedJson*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/6057b5-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/6057b5-approved.json
@@ -1,0 +1,9 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldThrowAssertionErrorWhenModelDiffersFromApprovedJson*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/6e6a31-idTest-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/6e6a31-idTest-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJsonWithUniqueId*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanLong": 6,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0,
+  "beanBoolean": true
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/78b1d8-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/78b1d8-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJson*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanLong": 6,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0,
+  "beanBoolean": true
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/964370-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/964370-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldThrowAssertionErrorWhenModelDiffersFromApprovedJson*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanLong": 5,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0,
+  "beanBoolean": false
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/bean-with-primitive-values-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/bean-with-primitive-values-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJsonWithFileName*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanLong": 6,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0,
+  "beanBoolean": true
+}

--- a/src/test/java/com/shazam/shazamcrest/63c5a4/f2f651-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/63c5a4/f2f651-approved.json
@@ -1,0 +1,6 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldNotThrowAssertionErrorWhenModelAsStringIsSameAsApprovedJson*/
+{
+  "beanLong": 5,
+  "beanString": "dummyString",
+  "beanInt": 10
+}

--- a/src/test/java/com/shazam/shazamcrest/AbstractJsonMatcherTest.java
+++ b/src/test/java/com/shazam/shazamcrest/AbstractJsonMatcherTest.java
@@ -6,7 +6,7 @@ import com.shazam.shazamcrest.model.BeanWithPrimitives;
  * @author Andras_Gyuro
  *
  */
-public class AbstractJsonMatcherTest {
+public abstract class AbstractJsonMatcherTest {
 
 	protected BeanWithPrimitives getBeanWithPrimitives(){
 		short beanShort = 1;

--- a/src/test/java/com/shazam/shazamcrest/AbstractJsonMatcherTest.java
+++ b/src/test/java/com/shazam/shazamcrest/AbstractJsonMatcherTest.java
@@ -1,0 +1,38 @@
+package com.shazam.shazamcrest;
+
+import com.shazam.shazamcrest.model.BeanWithPrimitives;
+/**
+ * Abstract class for common methods used by the JsonMatcher tests.
+ * @author Andras_Gyuro
+ *
+ */
+public class AbstractJsonMatcherTest {
+
+	protected BeanWithPrimitives getBeanWithPrimitives(){
+		short beanShort = 1;
+		boolean beanBoolean = true;
+		byte beanByte = 2;
+		char beanChar = 'c';
+		float beanFloat = 3f;
+		int beanInt = 4;
+		double beanDouble = 5d;
+		long beanLong = 6L;
+
+		BeanWithPrimitives bean = BeanWithPrimitives.Builder.beanWithPrimitives()
+				.beanShort(beanShort)
+				.beanBoolean(beanBoolean)
+				.beanByte(beanByte)
+				.beanChar(beanChar)
+				.beanFloat(beanFloat)
+				.beanInt(beanInt)
+				.beanDouble(beanDouble)
+				.beanLong(beanLong)
+				.build();
+
+		return bean;
+	}
+
+	protected String getBeanAsJsonString(){
+		return "{ beanLong: 5, beanString: \"dummyString\", beanInt: 10  }";
+	}
+}

--- a/src/test/java/com/shazam/shazamcrest/JsonMatcherBeanWithPrimitivesTest.java
+++ b/src/test/java/com/shazam/shazamcrest/JsonMatcherBeanWithPrimitivesTest.java
@@ -1,0 +1,99 @@
+package com.shazam.shazamcrest;
+
+import static com.shazam.shazamcrest.MatcherAssert.assertThat;
+import static com.shazam.shazamcrest.matcher.Matchers.sameJsonAsApproved;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+import org.junit.Test.None;
+
+import com.shazam.shazamcrest.model.BeanWithPrimitives;
+/**
+ * Unit tests which verify the basic usage of the
+ * {@link com.shazam.shazamcrest.matcher.Matchers#sameJsonAsApproved()} method.
+ * @author Andras_Gyuro
+ *
+ */
+public class JsonMatcherBeanWithPrimitivesTest {
+
+	private BeanWithPrimitives actual;
+
+	@Before
+	public void setUp(){
+		actual = getBeanWithPrimitives();
+	}
+
+
+	@Test(expected = None.class)
+	public void shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJson(){
+			assertThat(actual, sameJsonAsApproved());
+	}
+
+	@Test(expected = ComparisonFailure.class)
+	public void shouldThrowAssertionErrorWhenModelDiffersFromApprovedJson(){
+		assertThat(actual, sameJsonAsApproved());
+	}
+
+	@Test(expected = None.class)
+	public void shouldNotThrowAssertionErrorWhenModelDiffersFromApprovedJsonButFieldIsIgnored(){
+		assertThat(actual, sameJsonAsApproved().ignoring("beanLong").ignoring("beanBoolean"));
+	}
+
+	@Test(expected = None.class)
+	public void shouldNotThrowAssertionErrorWhenModelDiffersFromApprovedJsonButFieldIsIgnoredWithMatcher(){
+		Matcher<String> endsWithLongMatcher = Matchers.endsWith("Long");
+		Matcher<String> endsWithBooleanMatcher = Matchers.endsWith("Boolean");
+
+		assertThat(actual, sameJsonAsApproved().ignoring(endsWithLongMatcher).ignoring(endsWithBooleanMatcher));
+	}
+
+	@Test(expected = None.class)
+	public void shouldNotThrowAssertionErrorWhenModelDiffersFromApprovedJsonButFieldIsIgnoredWithClass(){
+		Matcher<String> endsWithLongMatcher = Matchers.endsWith("Long");
+		Matcher<String> endsWithBooleanMatcher = Matchers.endsWith("Boolean");
+
+		assertThat(actual, sameJsonAsApproved().ignoring(Long.class).ignoring(Boolean.class));
+	}
+
+	@Test(expected = None.class)
+	public void shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJsonWithUniqueId(){
+			assertThat(actual, sameJsonAsApproved().withUniqueId("idTest"));
+	}
+
+	@Test(expected = None.class)
+	public void shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJsonWithFileName(){
+		assertThat(actual, sameJsonAsApproved().withFileName("bean-with-primitive-values"));
+	}
+
+	@Test(expected = None.class)
+	public void shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJsonWithFileNameAndPathName(){
+		assertThat(actual, sameJsonAsApproved().withPathName("src/test/jsons").withFileName("bean-with-primitive-values-2"));
+	}
+
+	private BeanWithPrimitives getBeanWithPrimitives(){
+		short beanShort = 1;
+		boolean beanBoolean = true;
+		byte beanByte = 2;
+		char beanChar = 'c';
+		float beanFloat = 3f;
+		int beanInt = 4;
+		double beanDouble = 5d;
+		long beanLong = 6L;
+
+		BeanWithPrimitives bean = BeanWithPrimitives.Builder.beanWithPrimitives()
+				.beanShort(beanShort)
+				.beanBoolean(beanBoolean)
+				.beanByte(beanByte)
+				.beanChar(beanChar)
+				.beanFloat(beanFloat)
+				.beanInt(beanInt)
+				.beanDouble(beanDouble)
+				.beanLong(beanLong)
+				.build();
+
+		return bean;
+	}
+}

--- a/src/test/java/com/shazam/shazamcrest/JsonMatcherBeanWithPrimitivesTest.java
+++ b/src/test/java/com/shazam/shazamcrest/JsonMatcherBeanWithPrimitivesTest.java
@@ -105,19 +105,19 @@ public class JsonMatcherBeanWithPrimitivesTest extends AbstractJsonMatcherTest {
 		private static final String LONG_SUFFIX = " Long_variable";
 
 		@Override
-    public Long deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context) throws JsonParseException {
-        Long result = null;
-        if (!json.isJsonNull()) {
-            String asString = json.getAsString();
-            result = Long.parseLong(asString.replace(LONG_SUFFIX, ""));
-        }
-        return result;
-    }
+		public Long deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context) throws JsonParseException {
+		        Long result = null;
+		        if (!json.isJsonNull()) {
+		            String asString = json.getAsString();
+		            result = Long.parseLong(asString.replace(LONG_SUFFIX, ""));
+		        }
+		        return result;
+		    }
 
-    @Override
-    public JsonElement serialize(final Long src, final Type typeOfSrc, final JsonSerializationContext context) {
-        return new JsonPrimitive(src+LONG_SUFFIX);
-    }
+		@Override
+		public JsonElement serialize(final Long src, final Type typeOfSrc, final JsonSerializationContext context) {
+		    return new JsonPrimitive(src+LONG_SUFFIX);
+		}
 
 }
 

--- a/src/test/java/com/shazam/shazamcrest/JsonMatcherSampleTest.java
+++ b/src/test/java/com/shazam/shazamcrest/JsonMatcherSampleTest.java
@@ -1,7 +1,5 @@
 package com.shazam.shazamcrest;
 
-import java.util.Date;
-
 import org.junit.Test;
 
 import com.shazam.shazamcrest.matcher.Matchers;
@@ -21,16 +19,16 @@ public class JsonMatcherSampleTest {
 	 * file name.
 	 *
 	 * The following example will create 'abe6b8\fc5014-not-approved.json' which must be renamed
-	 * to 'abe6b8\fc5014-approved.json' after it's contents has been verified.
-	 * The next test run will find this approved file and will assert it's contents to the actual beanChild
+	 * to 'abe6b8\fc5014-approved.json' after its contents has been verified.
+	 * The next test run will find this approved file and will assert its contents to the actual beanChild
 	 * object.
 	 */
 	@Test
 	public void testWithSameJsonAsApprovedMatcher(){
-			DummyBean beanParent = new DummyBean(1, "a parent bean", true, null);
-			DummyBean beanChild = new DummyBean(2, "a child bean", false, beanParent);
+		DummyBean beanParent = new DummyBean(1, "a parent bean", true, null);
+		DummyBean beanChild = new DummyBean(2, "a child bean", false, beanParent);
 
-			MatcherAssert.assertThat(beanChild, Matchers.sameJsonAsApproved());
+		MatcherAssert.assertThat(beanChild, Matchers.sameJsonAsApproved());
 	}
 
 
@@ -38,7 +36,6 @@ public class JsonMatcherSampleTest {
 
 		private int beanInt;
 		private String beanString;
-		private Date beanDate;
 		private boolean beanBoolean;
 		private DummyBean beanParent;
 
@@ -60,6 +57,10 @@ public class JsonMatcherSampleTest {
 
 		public boolean isBeanBoolean() {
 			return beanBoolean;
+		}
+
+		public DummyBean getBeanParent() {
+			return beanParent;
 		}
 
 	}

--- a/src/test/java/com/shazam/shazamcrest/JsonMatcherSampleTest.java
+++ b/src/test/java/com/shazam/shazamcrest/JsonMatcherSampleTest.java
@@ -1,0 +1,67 @@
+package com.shazam.shazamcrest;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+import com.shazam.shazamcrest.matcher.Matchers;
+
+/**
+ * Sample test for using {@link com.shazam.shazamcrest.matcher.Matchers#sameJsonAsApproved()}.
+ * @author Andras_Gyuro
+ *
+ */
+public class JsonMatcherSampleTest {
+
+	/**
+	 * An example for using the Matchers.sameJsonAsApproved() to verify an object.
+	 * When first run, the test will create the json file that must be checked and renamed by the developer.
+	 * The generated file name will be placed next to the test files in a directory. The generation algorithm
+	 * creates SHA-1 hashes from the name of the class and name of the test method and uses these to create the directory name and json
+	 * file name.
+	 *
+	 * The following example will create 'abe6b8\fc5014-not-approved.json' which must be renamed
+	 * to 'abe6b8\fc5014-approved.json' after it's contents has been verified.
+	 * The next test run will find this approved file and will assert it's contents to the actual beanChild
+	 * object.
+	 */
+	@Test
+	public void testWithSameJsonAsApprovedMatcher(){
+			DummyBean beanParent = new DummyBean(1, "a parent bean", true, null);
+			DummyBean beanChild = new DummyBean(2, "a child bean", false, beanParent);
+
+			MatcherAssert.assertThat(beanChild, Matchers.sameJsonAsApproved());
+	}
+
+
+	private class DummyBean{
+
+		private int beanInt;
+		private String beanString;
+		private Date beanDate;
+		private boolean beanBoolean;
+		private DummyBean beanParent;
+
+		public DummyBean(int beanInt, String beanString, boolean beanBoolean, DummyBean beanParent) {
+			super();
+			this.beanInt = beanInt;
+			this.beanString = beanString;
+			this.beanBoolean = beanBoolean;
+			this.beanParent = beanParent;
+		}
+
+		public int getBeanInt() {
+			return beanInt;
+		}
+
+		public String getBeanString() {
+			return beanString;
+		}
+
+		public boolean isBeanBoolean() {
+			return beanBoolean;
+		}
+
+	}
+
+}

--- a/src/test/java/com/shazam/shazamcrest/abe6b8/fc5014-approved.json
+++ b/src/test/java/com/shazam/shazamcrest/abe6b8/fc5014-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherSampleTest.testWithSameJsonAsApprovedMatcher*/
+{
+  "beanInt": 2,
+  "beanString": "a child bean",
+  "beanBoolean": false,
+  "beanParent": {
+    "beanInt": 1,
+    "beanString": "a parent bean",
+    "beanBoolean": true
+  }
+}

--- a/src/test/java/com/shazam/shazamcrest/matcher/JsonMatcherTest.java
+++ b/src/test/java/com/shazam/shazamcrest/matcher/JsonMatcherTest.java
@@ -1,0 +1,94 @@
+package com.shazam.shazamcrest.matcher;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.anyString;
+import static com.shazam.shazamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import java.io.File;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.shazam.shazamcrest.AbstractJsonMatcherTest;
+import com.shazam.shazamcrest.model.BeanWithPrimitives;
+
+/**
+ * Unit test for the {@link JsonMatcher}.
+ * Verifies creation of not approved files.
+ * @author Andras_Gyuro
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JsonMatcherTest extends AbstractJsonMatcherTest{
+
+	private static final String DUMMY_FILE_NAME = "fileName";
+	private static final String DUMMY_APPROVED_FILE_NAME = DUMMY_FILE_NAME+"-approved";
+	private static final String DUMMY_TEST_PATH = "DummyTestPath";
+	private static final String DUMMY_CLASS_NAME = "DummyClassName";
+	private static final String DUMMY_METHOD_NAME = "DummyMethodName";
+	private static final String CLASS_HASH = "31a03e";
+	private static final String METHOD_HASH = "f8e392";
+	private static final String DUMMY_FILE_NAME_WITH_PATH = DUMMY_TEST_PATH+File.separator+ CLASS_HASH+File.separator+METHOD_HASH;
+	private static final String DUMMY_COMMENT = DUMMY_CLASS_NAME+"."+DUMMY_METHOD_NAME;
+	@Mock
+	private JsonMatcherUtils utils;
+
+	@Test
+	public void testRunShouldCreateNotApprovedFileWhenNotExists() throws IOException{
+		File dummyFile = new File(DUMMY_APPROVED_FILE_NAME);
+		BeanWithPrimitives actual = getBeanWithPrimitives();
+
+		when(utils.getCallerTestMethodName()).thenReturn(DUMMY_METHOD_NAME);
+		when(utils.getCallerTestClassName()).thenReturn(DUMMY_CLASS_NAME);
+		when(utils.getApproved(DUMMY_FILE_NAME_WITH_PATH)).thenReturn(dummyFile);
+		when(utils.getCallerTestClassPath()).thenReturn(DUMMY_TEST_PATH);
+		when(utils.createNotApproved(Mockito.eq(DUMMY_FILE_NAME_WITH_PATH), anyString(), eq(DUMMY_COMMENT))).thenReturn(DUMMY_FILE_NAME);
+		JsonMatcher<BeanWithPrimitives> matcher =new JsonMatcher<BeanWithPrimitives>();
+		matcher.setJsonMatcherUtils(utils);
+
+		try{
+			assertThat(actual, matcher);
+		}catch(AssertionError er){
+			assertThat(er.getMessage(), is(getNotApprovedCreationMessage()));
+		}
+	}
+
+	@Test
+	public void testRunShouldCreateNotApprovedFileWhenNotExistsAndModelAsString() throws IOException{
+		File dummyFile = new File(DUMMY_APPROVED_FILE_NAME);
+		String actual = getBeanAsJsonString();
+
+		when(utils.getCallerTestMethodName()).thenReturn(DUMMY_METHOD_NAME);
+		when(utils.getCallerTestClassName()).thenReturn(DUMMY_CLASS_NAME);
+		when(utils.getApproved(DUMMY_FILE_NAME_WITH_PATH)).thenReturn(dummyFile);
+		when(utils.getCallerTestClassPath()).thenReturn(DUMMY_TEST_PATH);
+		when(utils.createNotApproved(Mockito.eq(DUMMY_FILE_NAME_WITH_PATH), anyString(), eq(DUMMY_COMMENT))).thenReturn(DUMMY_FILE_NAME);
+		JsonMatcher<String> matcher =new JsonMatcher<String>();
+		matcher.setJsonMatcherUtils(utils);
+
+		try{
+			assertThat(actual, matcher);
+		}catch(AssertionError er){
+			assertThat(er.getMessage(), is(getNotApprovedCreationMessage()));
+		}
+	}
+
+	private String getNotApprovedCreationMessage(){
+		StringBuilder builder = new StringBuilder();
+		builder.append("Not approved file created '");
+		builder.append(CLASS_HASH);
+		builder.append("\\");
+		builder.append(DUMMY_FILE_NAME);
+		builder.append("', please verify it's contents and rename it to '");
+		builder.append(DUMMY_APPROVED_FILE_NAME);
+		builder.append("'.");
+		return builder.toString();
+	}
+
+
+
+}

--- a/src/test/java/com/shazam/shazamcrest/model/Bean.java
+++ b/src/test/java/com/shazam/shazamcrest/model/Bean.java
@@ -14,8 +14,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.shazam.shazamcrest.model.Bean.Builder;
-
 /**
  * Simple bean used for tests
  */
@@ -28,7 +26,7 @@ public class Bean {
 	private HashSet<Bean> hashSet;
 	private HashMap<Bean, Bean> hashMap;
 	private Bean[] array;
-	
+
 	private Bean(Builder builder) {
 		string = builder.string;
 		integer = builder.integer;
@@ -38,7 +36,7 @@ public class Bean {
 		hashMap = builder.hashMap;
 		array = builder.array;
 	}
-	
+
 	public String getField1() {
 		return string;
 	}
@@ -55,42 +53,42 @@ public class Bean {
 		public static Builder bean() {
 			return new Builder();
 		}
-		
+
 		public Builder string(String string) {
 			this.string = string;
 			return this;
 		}
-		
+
 		public Builder integer(int integer) {
 			this.integer = integer;
 			return this;
 		}
-		
+
 		public Builder set(Set<Bean> set) {
 			this.set = set;
 			return this;
 		}
-		
+
 		public Builder map(Map<Bean, Bean> map) {
 			this.map = map;
 			return this;
 		}
-		
+
 		public Builder hashSet(HashSet<Bean> hashSet) {
 			this.hashSet = hashSet;
 			return this;
 		}
-		
+
 		public Builder hashMap(HashMap<Bean, Bean> hashMap) {
 			this.hashMap = hashMap;
 			return this;
 		}
-		
+
 		public Builder array(Bean... array) {
 			this.array = array;
 			return this;
 		}
-		
+
 		public Bean build() {
 			return new Bean(this);
 		}

--- a/src/test/java/com/shazam/shazamcrest/model/BeanWithPrimitives.java
+++ b/src/test/java/com/shazam/shazamcrest/model/BeanWithPrimitives.java
@@ -9,8 +9,6 @@
  */
 package com.shazam.shazamcrest.model;
 
-import com.shazam.shazamcrest.model.BeanWithPrimitives.Builder;
-
 /**
  * Bean with all java primitives, used for tests
  */
@@ -20,11 +18,11 @@ public class BeanWithPrimitives {
 	private byte beanByte;
 	private char beanChar;
 	private short beanShort;
-	private int beanLong;
+	private long beanLong;
 	private float beanFloat;
 	private double beanDouble;
 	private boolean beanBoolean;
-	
+
 	private BeanWithPrimitives(Builder builder) {
 		beanInteger = builder.beanInt;
 		beanByte = builder.beanByte;
@@ -41,7 +39,7 @@ public class BeanWithPrimitives {
 		private byte beanByte;
 		private char beanChar;
 		private short beanShort;
-		private int beanLong;
+		private long beanLong;
 		private float beanFloat;
 		private double beanDouble;
 		private boolean beanBoolean;
@@ -49,47 +47,47 @@ public class BeanWithPrimitives {
 		public static Builder beanWithPrimitives() {
 			return new Builder();
 		}
-		
+
 		public Builder beanInt(int beanInt) {
 			this.beanInt = beanInt;
 			return this;
 		}
-		
+
 		public Builder beanByte(byte beanByte) {
 			this.beanByte = beanByte;
 			return this;
 		}
-		
+
 		public Builder beanChar(char beanChar) {
 			this.beanChar = beanChar;
 			return this;
 		}
-		
+
 		public Builder beanShort(short beanShort) {
 			this.beanShort = beanShort;
 			return this;
 		}
-		
-		public Builder beanLong(int beanLong) {
+
+		public Builder beanLong(long beanLong) {
 			this.beanLong = beanLong;
 			return this;
 		}
-		
+
 		public Builder beanFloat(float beanFloat) {
 			this.beanFloat = beanFloat;
 			return this;
 		}
-		
+
 		public Builder beanDouble(double beanDouble) {
 			this.beanDouble = beanDouble;
 			return this;
 		}
-		
+
 		public Builder beanBoolean(boolean beanBoolean) {
 			this.beanBoolean = beanBoolean;
 			return this;
 		}
-		
+
 		public BeanWithPrimitives build() {
 			return new BeanWithPrimitives(this);
 		}

--- a/src/test/jsons/bean-with-primitive-values-2-approved.json
+++ b/src/test/jsons/bean-with-primitive-values-2-approved.json
@@ -1,0 +1,11 @@
+/*com.shazam.shazamcrest.JsonMatcherBeanWithPrimitivesTest.shouldNotThrowAssertionErrorWhenModelIsSameAsApprovedJsonWithFileNameAndPathName*/
+{
+  "beanInteger": 4,
+  "beanByte": 2,
+  "beanChar": "c",
+  "beanShort": 1,
+  "beanLong": 6,
+  "beanFloat": 3.0,
+  "beanDouble": 5.0,
+  "beanBoolean": true
+}


### PR DESCRIPTION
New matcher to ease creating expected DTOs.
The matcher takes no argument, it generates the "not approved" expected DTO, which must be verified and renamed by the developer. Subsequent runs will find the "approved" file and assert the actual object to its contents.
Useful for testing REST endpoints, where the response structure could be very complex 

Also extended the GsonProvider with an overloaded gson(...) method with a custom GsonConfiguration object, which can be used to define custom TypeAdapters and TypeHierarchyAdapters.

Special thanks goes to Gabor Karsai for the idea.

_Included JsonMatcherSampleTest.java:_

```
package com.shazam.shazamcrest;

import java.util.Date;

import org.junit.Test;

import com.shazam.shazamcrest.matcher.Matchers;

/**
 * Sample test for using {@link com.shazam.shazamcrest.matcher.Matchers#sameJsonAsApproved()}.
 * @author Andras_Gyuro
 *
 */
public class JsonMatcherSampleTest {

    /**
     * An example for using the Matchers.sameJsonAsApproved() to verify an object.
     * When first run, the test will create the json file that must be checked and renamed by the developer.
     * The generated file name will be placed next to the test files in a directory. The generation algorithm
     * creates SHA-1 hashes from the name of the class and name of the test method and uses these to create the directory name and json
     * file name.
     *
     * The following example will create 'abe6b8\fc5014-not-approved.json' which must be renamed
     * to 'abe6b8\fc5014-approved.json' after it's contents has been verified.
     * The next test run will find this approved file and will assert it's contents to the actual beanChild
     * object.
     */
    @Test
    public void testWithSameJsonAsApprovedMatcher(){
            DummyBean beanParent = new DummyBean(1, "a parent bean", true, null);
            DummyBean beanChild = new DummyBean(2, "a child bean", false, beanParent);

            MatcherAssert.assertThat(beanChild, Matchers.sameJsonAsApproved());
    }


    private class DummyBean{

        private int beanInt;
        private String beanString;
        private Date beanDate;
        private boolean beanBoolean;
        private DummyBean beanParent;

        public DummyBean(int beanInt, String beanString, boolean beanBoolean, DummyBean beanParent) {
            super();
            this.beanInt = beanInt;
            this.beanString = beanString;
            this.beanBoolean = beanBoolean;
            this.beanParent = beanParent;
        }

        public int getBeanInt() {
            return beanInt;
        }

        public String getBeanString() {
            return beanString;
        }

        public boolean isBeanBoolean() {
            return beanBoolean;
        }

    }

}

```

The generated 'abe6b8\fc5014-not-approved.json':

```
/*com.shazam.shazamcrest.JsonMatcherSampleTest.testWithSameJsonAsApprovedMatcher*/
{
  "beanInt": 2,
  "beanString": "a child bean",
  "beanBoolean": false,
  "beanParent": {
    "beanInt": 1,
    "beanString": "a parent bean",
    "beanBoolean": true
  }
}

```
