### PR TITLE
Tiny changes to error msg wording

### DIFF
--- a/src/main/java/com/github/karsaig/approvalcrest/matcher/ContentMatcher.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/matcher/ContentMatcher.java
@@ -132,10 +132,10 @@ public class ContentMatcher<T> extends DiagnosingMatcher<T> implements ApprovedF
 				String message;
 				if (testClassNameHash == null) {
 					message = "Not approved file created '" + createdFileName
-							+ "',\n please verify it's contents and rename it to '" + approvedFileName + "'.";
+							+ "';\n please verify its contents and rename it to '" + approvedFileName + "'.";
 				} else {
 					message = "Not approved file created '" + testClassNameHash + File.separator + createdFileName
-							+ "',\n please verify it's contents and rename it to '" + approvedFileName + "'.";
+							+ "';\n please verify its contents and rename it to '" + approvedFileName + "'.";
 				}
 				fail(message);
 

--- a/src/main/java/com/github/karsaig/approvalcrest/matcher/ContentMatcher.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/matcher/ContentMatcher.java
@@ -131,10 +131,10 @@ public class ContentMatcher<T> extends DiagnosingMatcher<T> implements ApprovedF
 						testClassName + "." + testMethodName);
 				String message;
 				if (testClassNameHash == null) {
-					message = "Not approved file created '" + createdFileName
+					message = "Not approved file created: '" + createdFileName
 							+ "';\n please verify its contents and rename it to '" + approvedFileName + "'.";
 				} else {
-					message = "Not approved file created '" + testClassNameHash + File.separator + createdFileName
+					message = "Not approved file created: '" + testClassNameHash + File.separator + createdFileName
 							+ "';\n please verify its contents and rename it to '" + approvedFileName + "'.";
 				}
 				fail(message);

--- a/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
@@ -287,10 +287,10 @@ public class JsonMatcher<T> extends DiagnosingMatcher<T> implements Customisable
 				String message;
 				if (testClassNameHash == null) {
 					message = "Not approved file created '" + createdFileName
-							+ "', please verify it's contents and rename it to '" + approvedFileName + "'.";
+							+ "', please verify its contents and rename it to '" + approvedFileName + "'.";
 				} else {
 					message = "Not approved file created '" + testClassNameHash + File.separator + createdFileName
-							+ "', please verify it's contents and rename it to '" + approvedFileName + "'.";
+							+ "', please verify its contents and rename it to '" + approvedFileName + "'.";
 				}
 				fail(message);
 

--- a/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
@@ -286,10 +286,10 @@ public class JsonMatcher<T> extends DiagnosingMatcher<T> implements Customisable
 				String createdFileName = fileStoreMatcherUtils.createNotApproved(fileNameWithPath, content, testClassName + "." + testMethodName);
 				String message;
 				if (testClassNameHash == null) {
-					message = "Not approved file created '" + createdFileName
+					message = "Not approved file created: '" + createdFileName
 							+ "'; please verify its contents and rename it to '" + approvedFileName + "'.";
 				} else {
-					message = "Not approved file created '" + testClassNameHash + File.separator + createdFileName
+					message = "Not approved file created: '" + testClassNameHash + File.separator + createdFileName
 							+ "'; please verify its contents and rename it to '" + approvedFileName + "'.";
 				}
 				fail(message);

--- a/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
@@ -287,10 +287,10 @@ public class JsonMatcher<T> extends DiagnosingMatcher<T> implements Customisable
 				String message;
 				if (testClassNameHash == null) {
 					message = "Not approved file created '" + createdFileName
-							+ "', please verify its contents and rename it to '" + approvedFileName + "'.";
+							+ "'; please verify its contents and rename it to '" + approvedFileName + "'.";
 				} else {
 					message = "Not approved file created '" + testClassNameHash + File.separator + createdFileName
-							+ "', please verify its contents and rename it to '" + approvedFileName + "'.";
+							+ "'; please verify its contents and rename it to '" + approvedFileName + "'.";
 				}
 				fail(message);
 


### PR DESCRIPTION
Improving error message wording only -- note that I've not taken the time to build & run tests with these changes, so if changes to this text could break a test, don't merge this PR... I can come back again when I have a little more time and do this properly.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/karsaig/approvalcrest/pull/4?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/karsaig/approvalcrest/pull/4'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>