### PR TITLE
Removed an NPE when running with data-driven tests.

### DIFF
--- a/src/main/java/com/github/karsaig/approvalcrest/matcher/FileStoreMatcherUtils.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/matcher/FileStoreMatcherUtils.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.lang.reflect.Method;
 
 import org.junit.Test;
 
@@ -116,7 +117,7 @@ public class FileStoreMatcherUtils {
 	 */
 	public String getCallerTestClassName() {
 		StackTraceElement testStackTraceElement = getTestStackTraceElement(Thread.currentThread().getStackTrace());
-		return testStackTraceElement.getClassName();
+		return testStackTraceElement != null ? testStackTraceElement.getClassName() : null;
 	}
 
 	/**
@@ -152,13 +153,24 @@ public class FileStoreMatcherUtils {
 		Class<?> clazz;
 		try {
 			clazz = Class.forName(fullClassName);
-			isTest = clazz.getMethod(element.getMethodName()).isAnnotationPresent(Test.class);
-
+			Method method = findMethod(clazz, element.getMethodName());
+			isTest = method != null && method.isAnnotationPresent(Test.class);
 		} catch (Throwable e) {
 			isTest = false;
 		}
 
 		return isTest;
+	}
+
+	private Method findMethod(Class clazz, String methodName) {
+		Method[] methods = clazz.getMethods();
+		for (int i = 0; i < methods.length; i++) {
+			Method method = methods[i];
+			if (method.getName().equals(methodName)) {
+				return method;
+			}
+		}
+		return null;
 	}
 
 	public String getFullFileName(final String fileName, final boolean approved) {


### PR DESCRIPTION
Fixes a problem where using data-driven tests causes an NPE in approvalcrest. 
NPE caused by getCallerTestClassName not handling null return from getTestStackTraceElement.
Since data driven tests have parameters, calling Class::getMethod with just the method name returns null.
Instead just find the method of the class by name, ignoring parameters.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/karsaig/approvalcrest/pull/7?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/karsaig/approvalcrest/pull/7'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>