### PR TITLE
Serialize Dates to a fixed time zone by default

### DIFF
--- a/src/main/java/com/github/karsaig/approvalcrest/matcher/GsonProvider.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/matcher/GsonProvider.java
@@ -129,7 +129,7 @@ class GsonProvider {
 
         registerExclusionStrategies(gsonBuilder, typesToIgnore, fieldsToIgnore);
 
-		gsonBuilder.registerTypeAdapterFactory(GMTBasedDateTypeAdapter.FACTORY);
+		gsonBuilder.registerTypeAdapterFactory(FixedZoneDateAdapter.FACTORY);
     }
 
 	private static void additionalConfiguration(final GsonConfiguration additionalConfig, final GsonBuilder gsonBuilder) {
@@ -305,10 +305,10 @@ class GsonProvider {
         }
     }
 
-	private static class GMTBasedDateTypeAdapter extends TypeAdapter<Date> {
+	private static class FixedZoneDateAdapter extends TypeAdapter<Date> {
 		static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
 			@Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-				return Date.class.isAssignableFrom(typeToken.getRawType()) ? (TypeAdapter<T>) new GMTBasedDateTypeAdapter() : null;
+				return Date.class.isAssignableFrom(typeToken.getRawType()) ? (TypeAdapter<T>) new FixedZoneDateAdapter() : null;
 			}
 		};
 


### PR DESCRIPTION
Currently dates are serialized using the time zone of the host machine when using sameJsonAsApproved().
This isn't a good default, since tests running on machines in different time zones may fail.
This PR changes the default GSON configuration to serialize `java.util.Date` using a fixed time zone (UTC).

The existing date format is retained to aid backward compatibility, however this may be a breaking change for users operating in time zones other than UTC, so merging this PR may require a major version increment.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/karsaig/approvalcrest/pull/8%23discussion_r219056748%22%2C%20%22https%3A//github.com/karsaig/approvalcrest/pull/8%23issuecomment-423131568%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/karsaig/approvalcrest/pull/8%23issuecomment-423131568%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20not%20a%20backward%20compatible%20change%2C%20so%20it%20can%27t%20be%20merged%20until%20either%20of%20the%20following%20is%20true%3A%5Cr%5Cn%5Cr%5Cn1.%20New%20major%20version%20is%20created%2C%20which%20is%20planned%20due%20to%20moving%20to%20Junit5%20and%20targeting%20Java%208%5Cr%5Cn2.%20The%20change%20is%20done%20in%20a%20way%2C%20existing%20uses%20work%20the%20same%20way%20without%20any%20change%2C%20and%20new%20behavior%20can%20be%20turned%20on%22%2C%20%22created_at%22%3A%20%222018-09-20T10%3A28%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/19534954%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/karsaig%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d5befe02a270b8b02e86f503486638e730f2c9bc%20src/main/java/com/github/karsaig/approvalcrest/matcher/GsonProvider.java%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/karsaig/approvalcrest/pull/8%23discussion_r219056748%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22i%20would%20give%20each%20factory%20instance%20a%20FIXED_ZONE_DATE_FORMAT%20instance%20so%20they%20dont%20need%20to%20synchromize.%20That%20way%20the%20timezone%20could%20be%20a%20factory%20parameter%20in%20the%20future.%22%2C%20%22created_at%22%3A%20%222018-09-20T07%3A13%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2527142%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kissmd%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/main/java/com/github/karsaig/approvalcrest/matcher/GsonProvider.java%3AL304-330%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull d5befe02a270b8b02e86f503486638e730f2c9bc src/main/java/com/github/karsaig/approvalcrest/matcher/GsonProvider.java 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/karsaig/approvalcrest/pull/8#discussion_r219056748'>File: src/main/java/com/github/karsaig/approvalcrest/matcher/GsonProvider.java:L304-330</a></b>
- <a href='https://github.com/kissmd'><img border=0 src='https://avatars3.githubusercontent.com/u/2527142?v=4' height=16 width=16></a> i would give each factory instance a FIXED_ZONE_DATE_FORMAT instance so they dont need to synchromize. That way the timezone could be a factory parameter in the future.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/karsaig/approvalcrest/pull/8#issuecomment-423131568'>General Comment</a></b>
- <a href='https://github.com/karsaig'><img border=0 src='https://avatars1.githubusercontent.com/u/19534954?v=4' height=16 width=16></a> This is not a backward compatible change, so it can't be merged until either of the following is true:
1. New major version is created, which is planned due to moving to Junit5 and targeting Java 8
2. The change is done in a way, existing uses work the same way without any change, and new behavior can be turned on


<a href='https://www.codereviewhub.com/karsaig/approvalcrest/pull/8?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/karsaig/approvalcrest/pull/8?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/karsaig/approvalcrest/pull/8'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>