### PR TITLE
Fixes NPE in actual object

### DIFF
--- a/src/main/java/com/github/karsaig/approvalcrest/BeanFinder.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/BeanFinder.java
@@ -33,6 +33,9 @@ public class BeanFinder {
 	}
 
 	private static Object findBeanAt(List<String> fields, Object object) {
+		if (object == null) {
+			throw new PathNullPointerException(fields.get(0));
+		}
 		for (Field field : getEveryField(object.getClass())) {
 			field.setAccessible(true);
 			if (headOf(fields).equals(field.getName())) {

--- a/src/main/java/com/github/karsaig/approvalcrest/PathNullPointerException.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/PathNullPointerException.java
@@ -4,7 +4,7 @@ public class PathNullPointerException extends NullPointerException {
 
     private final String path;
 
-    public PathNullPointerException(String path) {
+    PathNullPointerException(String path) {
         this.path = path;
     }
 

--- a/src/main/java/com/github/karsaig/approvalcrest/PathNullPointerException.java
+++ b/src/main/java/com/github/karsaig/approvalcrest/PathNullPointerException.java
@@ -1,0 +1,14 @@
+package com.github.karsaig.approvalcrest;
+
+public class PathNullPointerException extends NullPointerException {
+
+    private final String path;
+
+    public PathNullPointerException(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/test/java/com/github/karsaig/approvalcrest/MatcherAssertCustomMatchingDiagnosticTest.java
+++ b/src/test/java/com/github/karsaig/approvalcrest/MatcherAssertCustomMatchingDiagnosticTest.java
@@ -79,4 +79,18 @@ public class MatcherAssertCustomMatchingDiagnosticTest {
 			MatcherAssert.assertThat(e.getMessage(), endsWith("childBean.nonExistingField does not exist"));
 		}
 	}
+
+    @Test
+    public void doesNotIncludeParentBeanFromFieldPath() {
+        ParentBean.Builder expected = parent().childBean(child().childString("apple"));
+        ParentBean.Builder actual = parent();
+
+        try {
+            assertThat(actual, sameBeanAs(expected).with("childBean.childString", equalTo("apple")));
+            fail("Expected assertion error");
+        } catch (AssertionError e) {
+            MatcherAssert.assertThat(e.getMessage(), endsWith("and childBean.childString \"apple\"\n"
+                    + "     but: parent bean of childString is null"));
+        }
+    }
 }


### PR DESCRIPTION
Fixes a problem where null value parent bean from a field path, used for matching field, from actual object causes an NPE in approvalcrest.

1. We have a bean, having fields that are also complex beans.
2. Then, we want to assert some nested fields with a custom matcher.
3. We put a custom matcher on a path, that has multiple dot-separated parts.
4. And of the intermediate beans on the path is null.
5. In such case we get NPE, but I think AssertionError with appropriate description should be thrown instead.

Example:

1. expected : { child : { childString : "apple" } }
2. actual : {}
3. We use custom matcher for field "child.childString"
4. actual.child has null value
5. findBeanAt fails on NPE
6. I think AssertionError should be thrown because the actual object is not malformed, it's just not fulfilling the assertion

NPE is thrown from within BeanFinder#findBeanAt. It is not handled by  DiagnosingCustomisableMatcher#areCustomMatchersMatching
The solution is to throw an exception PathNullPointerException from BeanFinder#findBeanAt, which exception would be handled by DiagnosingCustomisableMatcher#areCustomMatchersMatching that returns false with adding a description to AssertionError.
The following test is passing thanks to the proposed solution.
