### PR TITLE
Small tweak to fileMatcherPassOnCreate option

### DIFF
--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/ContentMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/ContentMatcher.java
@@ -54,8 +54,8 @@ public class ContentMatcher<T> extends AbstractDiagnosingFileMatcher<T, ContentM
     protected boolean matches(Object actual, Description mismatchDescription) {
         boolean matches = false;
         init();
-        createNotApprovedFileIfNotExists(actual);
-        if (fileMatcherConfig.isPassOnCreateEnabled()) {
+        if (createNotApprovedFileIfNotExists(actual)
+                && fileMatcherConfig.isPassOnCreateEnabled()) {
             return true;
         }
         initExpectedFromFile();
@@ -80,8 +80,8 @@ public class ContentMatcher<T> extends AbstractDiagnosingFileMatcher<T, ContentM
         return WINDOWS_NEWLINE_PATTERN.matcher(input).replaceAll("\n");
     }
 
-    private void createNotApprovedFileIfNotExists(Object toApprove) {
-        createNotApprovedFileIfNotExists(toApprove, () -> {
+    private boolean createNotApprovedFileIfNotExists(Object toApprove) {
+        return createNotApprovedFileIfNotExists(toApprove, () -> {
             if (!String.class.isInstance(toApprove)) {
                 throw new IllegalArgumentException("Only String content matcher is supported!");
             }

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
@@ -111,8 +111,8 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
         circularReferenceTypes.addAll(getClassesWithCircularReferences(actual, matcherConfiguration));
         init();
         Gson gson = GsonProvider.gson(matcherConfiguration, circularReferenceTypes, configuration);
-        createNotApprovedFileIfNotExists(actual, gson);
-        if (fileMatcherConfig.isPassOnCreateEnabled()) {
+        if (createNotApprovedFileIfNotExists(actual, gson)
+                && fileMatcherConfig.isPassOnCreateEnabled()) {
             return true;
         }
         initExpectedFromFile();
@@ -200,8 +200,8 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
         return MARKER_PATTERN.matcher(json).replaceAll("");
     }
 
-    private void createNotApprovedFileIfNotExists(Object toApprove, Gson gson) {
-        createNotApprovedFileIfNotExists(toApprove, () -> serializeToJson(toApprove, gson));
+    private boolean createNotApprovedFileIfNotExists(Object toApprove, Gson gson) {
+        return createNotApprovedFileIfNotExists(toApprove, () -> serializeToJson(toApprove, gson));
     }
 
     private void overwriteApprovedFile(Object actual, Gson gson) {

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
@@ -109,7 +109,14 @@ public abstract class AbstractDiagnosingFileMatcher<T, U extends AbstractDiagnos
         return getAssertMessage(fileStoreMatcherUtils, t.getMessage());
     }
 
-    protected void createNotApprovedFileIfNotExists(Object toApprove, Supplier<String> content) {
+    /**
+     * Creates a file suffixed with -not-approved for the developer to verify, and rename.
+     *
+     * @param toApprove ?
+     * @param content The content to be added to the -not-approved file.
+     * @return true if the not-approved file was created, false otherwise.
+     */
+    protected boolean createNotApprovedFileIfNotExists(Object toApprove, Supplier<String> content) {
         Path approvedFile = fileStoreMatcherUtils.getApproved(fileNameWithPath);
 
         if (Files.notExists(approvedFile)) {
@@ -127,12 +134,13 @@ public abstract class AbstractDiagnosingFileMatcher<T, U extends AbstractDiagnos
                     }
                     fail(message);
                 }
-
+                return true;
             } catch (IOException e) {
                 throw new IllegalStateException(
                         String.format("Exception while creating not approved file %s", toApprove.toString()), e);
             }
         }
+        return false;
     }
 
     protected String getCommentLine() {


### PR DESCRIPTION
Only pass the test if we actually created a file. If there already exists a -approved file, then we should still assert the content.

Use case: one might turn on this option to extend some existing tests with an additional assertion. The new files are created as expected, but any errors in the existing -approved files will be ignored, only to be found later on CI.