### PR TITLE
Added the option to swap UUIDs in an -approved.json file with deterministic replacement values.

### DIFF
--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/MatcherConfiguration.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/MatcherConfiguration.java
@@ -20,6 +20,7 @@ public class MatcherConfiguration {
     private final List<Class<?>> typesToIgnore = new ArrayList<>();
     private final List<Matcher<String>> patternsToIgnore = new ArrayList<>();
     private final List<Function<Object, Boolean>> skipCircularReferenceCheck = new ArrayList<>();
+    private boolean stabilizeUUIDs = false;
 
     public MatcherConfiguration() {
         skipCircularReferenceCheck.add(o -> Path.class.isInstance(o));
@@ -105,5 +106,14 @@ public class MatcherConfiguration {
             skipCircularReferenceCheck.add(actual);
         }
         return this;
+    }
+    
+    public MatcherConfiguration setStabilizeUUIDs() {
+        this.stabilizeUUIDs = true;
+        return this;
+    }
+    
+    public boolean stabilizeUUIDs() {
+        return stabilizeUUIDs;
     }
 }

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/CustomisableMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/CustomisableMatcher.java
@@ -109,4 +109,6 @@ public interface CustomisableMatcher<T, U extends CustomisableMatcher<T, U>> ext
      */
     @SuppressWarnings({"unchecked", "varargs"})
     U skipCircularReferenceCheck(Function<Object, Boolean> matcher, Function<Object, Boolean>... matchers);
+
+    U stabilizeUUIDs();
 }

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -200,4 +200,10 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
         matcherConfiguration.addSkipCircularReferenceChecker(matcher).addSkipCircularReferenceChecker(matchers);
         return this;
     }
+
+    @Override
+    public DiagnosingCustomisableMatcher<T> stabilizeUUIDs() {
+        matcherConfiguration.setStabilizeUUIDs();
+        return this;
+    }
 }


### PR DESCRIPTION
This has the benefit that the -approved.json file remains static, while also preserving the semantics of the document - two UUID values that were the same as each other before will remain the same afterwards. UUIDs in JSON documents are typically used as pointers, so replacing the values consistently retains the pointer semantics while still allowing static file comparison.

Draft as this needs further testing, TODO comments indicate known missing test cases, and one unknown regarding JsonObject entrySet order.