### PR TITLE
Bump org.skyscreamer:jsonassert -> 2.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Changelog
 ===========
 
+Version 0.62.3 - 2024/05/27
+-----
+
+- Fix to work with JDK 17 & 21
+- Updated dependencies to Guava 33.2.0-jre, Gson 2.11.0, Commons-lang3 3.14.0
+- Testing with newer JUnit5 5.10.2
+
+Version 0.61.6 - 2023/08/28
+-----
+
+- Added support for directory name override
+- Updated dependencies to Guava 32.1.1
+- Testing with newer JUnit5 5.4.0
+
+Version 0.61.2 - 2022/11/17
+-----
+
+- Updated dependencies to Guava 31.1, Gson 2.10, Commons-lang3 3.12.0
+
+Version 0.61.1 - 2022/07/07
+-----
+
+- Update Gson to 2.9.0
+
 Version 0.60.3 - 2021/04/20
 -----
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To use add the following to your project's pom.xml:
     <dependency>
       <groupId>com.github.karsaig</groupId>
       <artifactId>approvalcrest</artifactId>
-      <version>0.61.2</version>
+      <version>0.62.3</version>
     </dependency>
 
 ### JUnit 5
@@ -162,7 +162,7 @@ To use add the following to your project's pom.xml:
     <dependency>
       <groupId>com.github.karsaig</groupId>
       <artifactId>approvalcrest-junit-jupiter</artifactId>
-      <version>0.61.2</version>
+      <version>0.62.3</version>
     </dependency>
 
 ### Kotlin JUnit 5
@@ -170,5 +170,5 @@ To use add the following to your project's pom.xml:
     <dependency>
       <groupId>com.github.karsaig</groupId>
       <artifactId>approvalcrest-junit-jupiter-kotlin</artifactId>
-      <version>0.61.2</version>
+      <version>0.62.3</version>
     </dependency>

--- a/approvalcrest-core/pom.xml
+++ b/approvalcrest-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.0</version>
+        <version>0.62.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/approvalcrest-core/pom.xml
+++ b/approvalcrest-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.2</version>
+        <version>0.62.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/approvalcrest-core/pom.xml
+++ b/approvalcrest-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.1</version>
+        <version>0.62.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/approvalcrest-core/pom.xml
+++ b/approvalcrest-core/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
-            <version>1.5.0</version>
+            <version>2.0-rc1</version>
         </dependency>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/approvalcrest-core/pom.xml
+++ b/approvalcrest-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.3</version>
+        <version>0.62.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/approvalcrest-integration-tests/pom.xml
+++ b/approvalcrest-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.3</version>
+        <version>0.62.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-integration-tests/pom.xml
+++ b/approvalcrest-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.1</version>
+        <version>0.62.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-integration-tests/pom.xml
+++ b/approvalcrest-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.2</version>
+        <version>0.62.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-integration-tests/pom.xml
+++ b/approvalcrest-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.0</version>
+        <version>0.62.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter-integration-tests/pom.xml
+++ b/approvalcrest-junit-jupiter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.0</version>
+        <version>0.62.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter-integration-tests/pom.xml
+++ b/approvalcrest-junit-jupiter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.2</version>
+        <version>0.62.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter-integration-tests/pom.xml
+++ b/approvalcrest-junit-jupiter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.1</version>
+        <version>0.62.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter-integration-tests/pom.xml
+++ b/approvalcrest-junit-jupiter-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.3</version>
+        <version>0.62.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter/pom.xml
+++ b/approvalcrest-junit-jupiter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.0</version>
+        <version>0.62.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter/pom.xml
+++ b/approvalcrest-junit-jupiter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.1</version>
+        <version>0.62.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter/pom.xml
+++ b/approvalcrest-junit-jupiter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.2</version>
+        <version>0.62.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-jupiter/pom.xml
+++ b/approvalcrest-junit-jupiter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.3</version>
+        <version>0.62.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-vintage-integration-tests/pom.xml
+++ b/approvalcrest-junit-vintage-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.0</version>
+        <version>0.62.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-vintage-integration-tests/pom.xml
+++ b/approvalcrest-junit-vintage-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.3</version>
+        <version>0.62.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-vintage-integration-tests/pom.xml
+++ b/approvalcrest-junit-vintage-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.1</version>
+        <version>0.62.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest-junit-vintage-integration-tests/pom.xml
+++ b/approvalcrest-junit-vintage-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.2</version>
+        <version>0.62.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-junit-jupiter</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest/pom.xml
+++ b/approvalcrest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.0</version>
+        <version>0.62.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.0</version>
+            <version>0.62.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest/pom.xml
+++ b/approvalcrest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.1</version>
+        <version>0.62.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.1</version>
+            <version>0.62.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest/pom.xml
+++ b/approvalcrest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.2</version>
+        <version>0.62.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.2</version>
+            <version>0.62.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/approvalcrest/pom.xml
+++ b/approvalcrest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.3</version>
+        <version>0.62.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>approvalcrest-core</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.github.karsaig</groupId>
             <artifactId>testing-common</artifactId>
-            <version>0.62.3</version>
+            <version>0.62.4-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/for-release-pom.xml
+++ b/for-release-pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.1</version>
+    <version>0.62.2</version>
     <modules>
         <module>approvalcrest</module>
         <module>approvalcrest-junit-jupiter</module>

--- a/for-release-pom.xml
+++ b/for-release-pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.3</version>
+    <version>0.62.4-SNAPSHOT</version>
     <modules>
         <module>approvalcrest</module>
         <module>approvalcrest-junit-jupiter</module>

--- a/for-release-pom.xml
+++ b/for-release-pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.0</version>
+    <version>0.62.1</version>
     <modules>
         <module>approvalcrest</module>
         <module>approvalcrest-junit-jupiter</module>

--- a/for-release-pom.xml
+++ b/for-release-pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.2</version>
+    <version>0.62.3</version>
     <modules>
         <module>approvalcrest</module>
         <module>approvalcrest-junit-jupiter</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.3</version>
+    <version>0.62.4-SNAPSHOT</version>
     <modules>
         <module>testing-common</module>
         <module>approvalcrest-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.2</version>
+    <version>0.62.3</version>
     <modules>
         <module>testing-common</module>
         <module>approvalcrest-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.0</version>
+    <version>0.62.1</version>
     <modules>
         <module>testing-common</module>
         <module>approvalcrest-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.karsaig</groupId>
     <artifactId>approvalcrest-parent</artifactId>
-    <version>0.62.1</version>
+    <version>0.62.2</version>
     <modules>
         <module>testing-common</module>
         <module>approvalcrest-core</module>

--- a/release.sh
+++ b/release.sh
@@ -17,9 +17,13 @@ mvn clean install -Djava.version.to.run="${jvtr}"
 mvn clean -Djava.version.to.run="${jvtr}"
 
 
-mvn -f for-release-pom.xml clean deploy -P sign-release,ossrh --settings ../../Installed/settings.xml -DskipRemoteStaging=true -Djava.version.to.run="${jvtr}"
+#mvn -f for-release-pom.xml clean deploy -P sign-release,ossrh --settings ../../Installed/settings.xml -DskipRemoteStaging=true -Djava.version.to.run="${jvtr}"
 
-mvn -f for-release-pom.xml nexus-staging:deploy-staged -P ossrh --settings ../../Installed/settings.xml -DstagingDescription="Description of the staged repository" -Djava.version.to.run="${jvtr}"
+#mvn -f for-release-pom.xml nexus-staging:deploy-staged -P ossrh --settings ../../Installed/settings.xml -DstagingDescription="Description of the staged repository" -Djava.version.to.run="${jvtr}"
+
+mvn -f for-release-pom.xml clean deploy -P sign-release,ossrh -DskipRemoteStaging=true -Djava.version.to.run="${jvtr}"
+
+mvn -f for-release-pom.xml nexus-staging:deploy-staged -P ossrh -DstagingDescription="Description of the staged repository" -Djava.version.to.run="${jvtr}"
 
 git clean -f
 git push

--- a/testing-common/pom.xml
+++ b/testing-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.1</version>
+        <version>0.62.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testing-common/pom.xml
+++ b/testing-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.0</version>
+        <version>0.62.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testing-common/pom.xml
+++ b/testing-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.2</version>
+        <version>0.62.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testing-common/pom.xml
+++ b/testing-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvalcrest-parent</artifactId>
         <groupId>com.github.karsaig</groupId>
-        <version>0.62.3</version>
+        <version>0.62.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This version removes vendored org.json classes, which prevents duplicate class issues when org.json module is separately included.