### PR TITLE
Update docs to reference JUnit 5 & 6 instead of JUnit 5 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Choose the artifact that matches your test runner.
 </dependency>
 ```
 
-### JUnit 5 Jupiter
+### JUnit 5 & 6 Jupiter
 
 ```xml
 <dependency>
@@ -78,7 +78,7 @@ Choose the artifact that matches your test runner.
 </dependency>
 ```
 
-### Kotlin + JUnit 5
+### Kotlin + JUnit 5 & 6
 
 ```xml
 <dependency>
@@ -120,7 +120,7 @@ For Gradle, replace the `<dependency>` blocks with the equivalent `testImplement
 | [Supported types](docs/supported-types.md) | java.time.\*, Optional, Path, Throwable, circular references |
 | [Best practices](docs/best-practices.md) | State management, CI workflow, approved file discipline |
 | [JUnit 4 & Vintage](docs/junit4-vintage.md) | JUnit 4 / JUnit 5 Vintage specifics |
-| [JUnit 5 Jupiter](docs/junit5-jupiter.md) | JUnit 5 Jupiter specifics |
+| [JUnit 5 & 6 Jupiter](docs/junit5-jupiter.md) | JUnit 5 & 6 Jupiter specifics |
 | [TestNG](docs/testng.md) | TestNG specifics |
 | [Kotlin](docs/kotlin.md) | Kotlin extension functions and KT-5464 workaround |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,8 +7,8 @@ Add approvalcrest to your project and write your first assertion in minutes.
 | Test framework | Artifact |
 |---|---|
 | JUnit 4 / JUnit 5 Vintage | `com.github.karsaig:approvalcrest:1.1.0` |
-| JUnit 5 Jupiter (Java) | `com.github.karsaig:approvalcrest-junit-jupiter:1.1.0` |
-| Kotlin + JUnit 5 | `com.github.karsaig:approvalcrest-junit-jupiter-kotlin:1.1.0` |
+| JUnit 5 & 6 Jupiter (Java) | `com.github.karsaig:approvalcrest-junit-jupiter:1.1.0` |
+| Kotlin + JUnit 5 & 6 | `com.github.karsaig:approvalcrest-junit-jupiter-kotlin:1.1.0` |
 | TestNG | `com.github.karsaig:approvalcrest-testng:1.1.0` |
 
 ### JUnit 4 / Vintage (Maven)
@@ -22,7 +22,7 @@ Add approvalcrest to your project and write your first assertion in minutes.
 </dependency>
 ```
 
-### JUnit 5 Jupiter (Maven)
+### JUnit 5 & 6 Jupiter (Maven)
 
 ```xml
 <dependency>
@@ -33,7 +33,7 @@ Add approvalcrest to your project and write your first assertion in minutes.
 </dependency>
 ```
 
-### Kotlin + JUnit 5 (Maven)
+### Kotlin + JUnit 5 & 6 (Maven)
 
 ```xml
 <dependency>

--- a/docs/junit5-jupiter.md
+++ b/docs/junit5-jupiter.md
@@ -1,6 +1,6 @@
 # junit5-jupiter
 
-Using approvalcrest with JUnit 5 Jupiter (Java).
+Using approvalcrest with JUnit 5 & 6 Jupiter (Java). The `approvalcrest-junit-jupiter` artifact works with both JUnit 5 and JUnit 6 (JUnit Platform) without any code changes.
 
 ## Dependency
 
@@ -37,7 +37,7 @@ public void myTest() {
 
 ## Parameterized Tests
 
-Add `TestInfo` as a parameter — JUnit 5 injects it automatically. Pass it to `sameJsonAsApproved(testInfo)` so the matcher can resolve the correct test method. Use `.withUniqueId(name)` to create a separate approved file per case:
+Add `TestInfo` as a parameter — JUnit 5 & 6 inject it automatically. Pass it to `sameJsonAsApproved(testInfo)` so the matcher can resolve the correct test method. Use `.withUniqueId(name)` to create a separate approved file per case:
 
 ```java
 @ParameterizedTest
@@ -76,10 +76,6 @@ Verify that an assertion fails with a specific matcher:
 assertThrows(sameBeanAs(expectedException),
     () -> assertThat(actual, sameBeanAs(wrongExpected)));
 ```
-
-## JUnit 6 Compatibility
-
-The `approvalcrest-junit-jupiter` module is verified against **JUnit Platform 6** (tested on JUnit 6.1.0 with Java 17, 21, and 25). No code changes are needed to run on JUnit 6 — the existing dependency and API work without modification.
 
 ## Related
 

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -1,6 +1,6 @@
 # kotlin
 
-Using approvalcrest with Kotlin and JUnit 5.
+Using approvalcrest with Kotlin and JUnit 5 & 6.
 
 ## Dependency
 
@@ -69,7 +69,7 @@ assertThat("content", sameContentAsApproved<String>().withUniqueId("myCase"))
 
 ## Parameterized Tests
 
-Same pattern as JUnit 5 Java — add `TestInfo` as a parameter:
+Same pattern as JUnit 5 & 6 Java — add `TestInfo` as a parameter:
 
 ```kotlin
 @ParameterizedTest

--- a/docs/same-content-as-approved.md
+++ b/docs/same-content-as-approved.md
@@ -29,7 +29,7 @@ void assertContent() {
 3. **Rename** to `*-approved.content`.
 4. **Subsequent runs** compare against the approved file.
 
-## Parameterized Tests (JUnit 5)
+## Parameterized Tests (JUnit 5 & 6)
 
 Pass `TestInfo` and combine with `.withUniqueId()` to create a separate approved file per case:
 

--- a/docs/same-json-as-approved.md
+++ b/docs/same-json-as-approved.md
@@ -36,9 +36,9 @@ void rawJsonStringMatchesApprovedFile() {
 }
 ```
 
-## Parameterized Tests (JUnit 5)
+## Parameterized Tests (JUnit 5 & 6)
 
-Add `TestInfo` as a test parameter — JUnit 5 injects it automatically. Pass it to `sameJsonAsApproved(testInfo)` so the matcher can resolve the correct test method. Use `.withUniqueId(name)` to create a separate approved file per case:
+Add `TestInfo` as a test parameter — JUnit 5 & 6 inject it automatically. Pass it to `sameJsonAsApproved(testInfo)` so the matcher can resolve the correct test method. Use `.withUniqueId(name)` to create a separate approved file per case:
 
 ```java
 @ParameterizedTest
@@ -63,4 +63,4 @@ JUnit 4 requires a `Junit4DesciptionWatcher` rule. See [junit4-vintage](junit4-v
 - [sorting](sorting.md) — stabilise collection order
 - [supported-types](supported-types.md) — how common Java types are serialised
 - [junit4-vintage](junit4-vintage.md) — JUnit 4 / Vintage usage
-- [junit5-jupiter](junit5-jupiter.md) — JUnit 5 Jupiter usage
+- [junit5-jupiter](junit5-jupiter.md) — JUnit 5 & 6 Jupiter usage


### PR DESCRIPTION
The approvalcrest-junit-jupiter artifact works with both JUnit 5 and JUnit 6 without code changes. Update all user-facing documentation to reflect this: headings, table rows, and prose descriptions now say 'JUnit 5 & 6'. File names and package names are unchanged.