### PR TITLE
Migrate machine-readable output to structured JSON with ignoredFields/aliasedFields tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ assertThat(actual, sameJsonAsApproved().withMachineReadableOutput());
 mvn test -DfileMatcherMachineReadable=true
 ```
 
-In this mode, failure messages are structured JSON containing the expected/actual content, the approved file path, an `ignoredFields` array showing which fields were removed and why, and an `aliasedFields` array showing value replacements. See [file-control.md](docs/file-control.md) for details.
+In this mode, failure messages are structured JSON containing the expected/actual content, the approved file path, an `ignoredFields` array showing which fields were removed and why, an `aliasedFields` array showing value replacements, and a `sortedFields` array showing which arrays were sorted. See [file-control.md](docs/file-control.md) for details.
 
 ## Version support
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ assertThat(actual, sameJsonAsApproved().withMachineReadableOutput());
 mvn test -DfileMatcherMachineReadable=true
 ```
 
-In this mode, failure messages include absolute paths to approved files, full `=== ACTUAL (full) ===` content blocks, and a tip to re-run with `-DfileMatcherUpdateInPlace=true`. See [file-control.md](docs/file-control.md) for details.
+In this mode, failure messages are structured JSON containing the expected/actual content, the approved file path, an `ignoredFields` array showing which fields were removed and why, and an `aliasedFields` array showing value replacements. See [file-control.md](docs/file-control.md) for details.
 
 ## Version support
 

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
@@ -11,12 +11,22 @@ package com.github.karsaig.approvalcrest;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.List;
+
+import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.hamcrest.StringDescription;
 
 /**
  * {@link StringDescription} which holds the mismatch message along with the actual and expected Json representation.
  */
 public class ComparisonDescription extends StringDescription {
+	private static final Gson OUTPUT_GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
 	private String actual;
 	private String expected;
 	private String differencesMessage;
@@ -24,6 +34,9 @@ public class ComparisonDescription extends StringDescription {
 	private boolean machineReadable;
 	private String approvedFilePath;
 	private String testInfo;
+	private IgnoredFieldsTracker ignoredFieldsTracker;
+	private AliasTracker aliasTracker;
+	private String note;
 
 	public String getActual() {
 		return actual;
@@ -73,6 +86,25 @@ public class ComparisonDescription extends StringDescription {
 		this.testInfo = testInfo;
 	}
 
+	public void setIgnoredFieldsTracker(IgnoredFieldsTracker tracker) {
+		this.ignoredFieldsTracker = tracker;
+	}
+
+	public void setAliasTracker(AliasTracker tracker) {
+		this.aliasTracker = tracker;
+	}
+
+	public void setTypesIgnoredConfigured(boolean typesIgnoredConfigured) {
+		// Legacy compatibility — builds the note string
+		if (typesIgnoredConfigured) {
+			setNote("Type-based ignoring is configured but field-level tracking is not available for it.");
+		}
+	}
+
+	public void setNote(String note) {
+		this.note = note;
+	}
+
 	public String toFailureMessage(String reason) {
 		if (machineReadable) {
 			return buildMachineReadableMessage(reason);
@@ -82,24 +114,63 @@ public class ComparisonDescription extends StringDescription {
 	}
 
 	private String buildMachineReadableMessage(String reason) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("FAILURE_TYPE: MISMATCH\n");
+		JsonObject root = new JsonObject();
+		root.addProperty("failureType", "MISMATCH");
 		if (testInfo != null) {
-			sb.append("TEST: ").append(testInfo).append("\n");
-		}
-		if (isNotBlank(reason)) {
-			sb.append(reason).append("\n");
+			root.addProperty("test", testInfo);
 		}
 		if (approvedFilePath != null) {
-			sb.append("APPROVED_FILE: ").append(approvedFilePath).append("\n");
-			sb.append("ACTION: Set system property fMUInPlace=true and re-run to update the approved file\n");
-		} else if (expected != null) {
-			sb.append("=== EXPECTED (full) ===\n").append(expected).append("\n=== END EXPECTED ===\n");
+			root.addProperty("approvedFile", approvedFilePath);
+			root.addProperty("action", "Set system property fMUInPlace=true and re-run to update the approved file");
 		}
-		sb.append("\n");
+		if (expected != null) {
+			root.addProperty("expected", expected);
+		}
 		if (actual != null) {
-			sb.append("=== ACTUAL (full) ===\n").append(actual).append("\n=== END ACTUAL ===");
+			root.addProperty("actual", actual);
 		}
-		return sb.toString();
+		root.add("ignoredFields", buildIgnoredFieldsArray());
+		root.add("aliasedFields", buildAliasedFieldsArray());
+		if (note != null) {
+			root.addProperty("note", note);
+		}
+		return OUTPUT_GSON.toJson(root);
+	}
+
+	private JsonArray buildIgnoredFieldsArray() {
+		JsonArray arr = new JsonArray();
+		if (ignoredFieldsTracker != null && !ignoredFieldsTracker.isEmpty()) {
+			for (IgnoredFieldsTracker.IgnoredField field : ignoredFieldsTracker.getFields()) {
+				JsonObject entry = new JsonObject();
+				entry.addProperty("path", field.getPath());
+				entry.addProperty("reason", field.getReason().name());
+				if (field.getPattern() != null) {
+					entry.addProperty("pattern", field.getPattern());
+				}
+				if (field.getCauses() != null && !field.getCauses().isEmpty()) {
+					JsonArray causes = new JsonArray();
+					for (String cause : field.getCauses()) {
+						causes.add(cause);
+					}
+					entry.add("causes", causes);
+				}
+				arr.add(entry);
+			}
+		}
+		return arr;
+	}
+
+	private JsonArray buildAliasedFieldsArray() {
+		JsonArray arr = new JsonArray();
+		if (aliasTracker != null && !aliasTracker.isEmpty()) {
+			for (AliasTracker.AliasedField field : aliasTracker.getFields()) {
+				JsonObject entry = new JsonObject();
+				entry.addProperty("path", field.getPath());
+				entry.addProperty("originalValue", field.getOriginalValue());
+				entry.addProperty("alias", field.getAlias());
+				arr.add(entry);
+			}
+		}
+		return arr;
 	}
 }

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.SortedFieldsTracker;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -36,6 +37,7 @@ public class ComparisonDescription extends StringDescription {
 	private String testInfo;
 	private IgnoredFieldsTracker ignoredFieldsTracker;
 	private AliasTracker aliasTracker;
+	private SortedFieldsTracker sortedFieldsTracker;
 	private String note;
 
 	public String getActual() {
@@ -94,6 +96,10 @@ public class ComparisonDescription extends StringDescription {
 		this.aliasTracker = tracker;
 	}
 
+	public void setSortedFieldsTracker(SortedFieldsTracker tracker) {
+		this.sortedFieldsTracker = tracker;
+	}
+
 	public void setTypesIgnoredConfigured(boolean typesIgnoredConfigured) {
 		// Legacy compatibility — builds the note string
 		if (typesIgnoredConfigured) {
@@ -131,6 +137,7 @@ public class ComparisonDescription extends StringDescription {
 		}
 		root.add("ignoredFields", buildIgnoredFieldsArray());
 		root.add("aliasedFields", buildAliasedFieldsArray());
+		root.add("sortedFields", buildSortedFieldsArray());
 		if (note != null) {
 			root.addProperty("note", note);
 		}
@@ -168,6 +175,22 @@ public class ComparisonDescription extends StringDescription {
 				entry.addProperty("path", field.getPath());
 				entry.addProperty("originalValue", field.getOriginalValue());
 				entry.addProperty("alias", field.getAlias());
+				arr.add(entry);
+			}
+		}
+		return arr;
+	}
+
+	private JsonArray buildSortedFieldsArray() {
+		JsonArray arr = new JsonArray();
+		if (sortedFieldsTracker != null && !sortedFieldsTracker.isEmpty()) {
+			for (SortedFieldsTracker.SortedField field : sortedFieldsTracker.getFields()) {
+				JsonObject entry = new JsonObject();
+				entry.addProperty("path", field.getPath());
+				entry.addProperty("reason", field.getReason().name());
+				if (field.getPattern() != null) {
+					entry.addProperty("pattern", field.getPattern());
+				}
 				arr.add(entry);
 			}
 		}

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/FieldsIgnorer.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/FieldsIgnorer.java
@@ -10,6 +10,7 @@
 package com.github.karsaig.approvalcrest;
 
 import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.SortedFieldsTracker;
 import com.github.karsaig.approvalcrest.matcher.sorting.SortField;
 import com.google.gson.*;
 import org.hamcrest.Matcher;
@@ -34,19 +35,27 @@ public class FieldsIgnorer {
     }
 
     public static void applyRootCollectionSorting(JsonElement filteredJson, Object objectForTypeCheck, List<SortField<Matcher<String>>> fieldMatchersToSort, Map<String, List<SortField<String>>> pathsToSort) {
-        applyRootCollectionSorting(filteredJson, objectForTypeCheck, fieldMatchersToSort, pathsToSort, Collections.<Class<?>>emptyList());
+        applyRootCollectionSorting(filteredJson, objectForTypeCheck, fieldMatchersToSort, pathsToSort, Collections.<Class<?>>emptyList(), null);
     }
 
     public static void applyRootCollectionSorting(JsonElement filteredJson, Object objectForTypeCheck, List<SortField<Matcher<String>>> fieldMatchersToSort, Map<String, List<SortField<String>>> pathsToSort, Collection<Class<?>> typesToSort) {
+        applyRootCollectionSorting(filteredJson, objectForTypeCheck, fieldMatchersToSort, pathsToSort, typesToSort, null);
+    }
+
+    public static void applyRootCollectionSorting(JsonElement filteredJson, Object objectForTypeCheck, List<SortField<Matcher<String>>> fieldMatchersToSort, Map<String, List<SortField<String>>> pathsToSort, Collection<Class<?>> typesToSort, SortedFieldsTracker tracker) {
         if (objectForTypeCheck != null && (Set.class.isAssignableFrom(objectForTypeCheck.getClass()) || Map.class.isAssignableFrom(objectForTypeCheck.getClass()))) {
-            // Sets and Maps are always sorted by their root representation (no meaningful order)
+            // Sets and Maps are always sorted by their root representation (no meaningful order) — NOT tracked
             sortJsonArray(filteredJson.getAsJsonArray(), pathsToSort.getOrDefault("", emptyList()), fieldMatchersToSort);
         } else if (objectForTypeCheck != null && Collection.class.isAssignableFrom(objectForTypeCheck.getClass())) {
             // Other Collections (e.g. List) are sorted only when explicitly configured via "" path
             List<SortField<String>> rootSortFields = pathsToSort.getOrDefault("", emptyList());
             if (!rootSortFields.isEmpty() || !fieldMatchersToSort.isEmpty()) {
                 sortJsonArray(filteredJson.getAsJsonArray(), rootSortFields, fieldMatchersToSort);
+                if (tracker != null) {
+                    recordSortMatches(tracker, "", rootSortFields, fieldMatchersToSort);
+                }
             } else if (!typesToSort.isEmpty() && collectionElementMatchesTypesToSort((Collection<?>) objectForTypeCheck, typesToSort)) {
+                // Type-based sorting — NOT tracked (same as type-based ignoring)
                 sortJsonArray(filteredJson.getAsJsonArray(), emptyList(), fieldMatchersToSort);
             }
         }
@@ -193,14 +202,19 @@ public class FieldsIgnorer {
     }
 
     public static void applySorting(JsonElement jsonElement, Map<String, List<SortField<String>>> pathsToSort, List<SortField<Matcher<String>>> fieldMatchersToSort, boolean sortFile) {
+        applySorting(jsonElement, pathsToSort, fieldMatchersToSort, sortFile, null);
+    }
+
+    public static void applySorting(JsonElement jsonElement, Map<String, List<SortField<String>>> pathsToSort, List<SortField<Matcher<String>>> fieldMatchersToSort, boolean sortFile, SortedFieldsTracker tracker) {
         if (jsonElement == null || jsonElement.isJsonNull()) return;
         Map<String, PathLevel> pathMap = pathsToSort.isEmpty() ? Collections.emptyMap() : getPathsMap(pathsToSort);
-        applySortingInternal(jsonElement, pathMap, pathsToSort, fieldMatchersToSort, sortFile);
+        applySortingInternal(jsonElement, pathMap, pathsToSort, fieldMatchersToSort, sortFile, tracker, "");
     }
 
     private static void applySortingInternal(JsonElement jsonElement, Map<String, PathLevel> pathMap,
             Map<String, List<SortField<String>>> pathsToSort,
-            List<SortField<Matcher<String>>> fieldMatchersToSort, boolean sortFile) {
+            List<SortField<Matcher<String>>> fieldMatchersToSort, boolean sortFile,
+            SortedFieldsTracker tracker, String currentPath) {
         if (jsonElement != null && !jsonElement.isJsonNull()) {
             if (jsonElement.isJsonObject()) {
                 JsonObject jsonObject = jsonElement.getAsJsonObject();
@@ -222,12 +236,16 @@ public class FieldsIgnorer {
                     PathLevel pathLevel = pathMap.getOrDefault(fieldNamePair.newKey, PathLevel.EMPTY);
                     Map<String, PathLevel> nextPathMap = pathLevel.nextLevel.isEmpty()
                             ? Collections.emptyMap() : getPathsMap(pathLevel.nextLevel);
-                    applySortingInternal(actualValue, nextPathMap, pathLevel.nextLevel, fieldMatchersToSort, sortFile);
+                    String childPath = currentPath.isEmpty() ? fieldNamePair.newKey : currentPath + "." + fieldNamePair.newKey;
+                    applySortingInternal(actualValue, nextPathMap, pathLevel.nextLevel, fieldMatchersToSort, sortFile, tracker, childPath);
                     if (actualValue.isJsonArray()) {
                         List<SortField<String>> matchingPathMatchers = anyPathMatch(fieldNamePair.newKey, pathMap, sortFile);
                         List<SortField<Matcher<String>>> matchingFieldMatchers = anyFieldMatcherMatches(fieldNamePair.newKey, fieldMatchersToSort, sortFile);
                         if (fieldNamePair.shouldSortDueToType() || !matchingPathMatchers.isEmpty() || !matchingFieldMatchers.isEmpty()) {
                             sortJsonArray(actualValue.getAsJsonArray(), matchingPathMatchers, matchingFieldMatchers);
+                            if (tracker != null) {
+                                recordSortMatches(tracker, childPath, matchingPathMatchers, matchingFieldMatchers);
+                            }
                         }
                     }
                 }
@@ -256,7 +274,7 @@ public class FieldsIgnorer {
                     if (current.isJsonNull() || current.isJsonPrimitive()) {
                         continue;
                     }
-                    applySortingInternal(current, innerPathMap, innerPathsToSort, fieldMatchersToSort, sortFile);
+                    applySortingInternal(current, innerPathMap, innerPathsToSort, fieldMatchersToSort, sortFile, tracker, currentPath);
                 }
                 // Sort the array itself last (root), so the sort key reflects the
                 // already-sorted state of nested elements.
@@ -264,8 +282,22 @@ public class FieldsIgnorer {
                 List<SortField<Matcher<String>>> rootFieldMatchers = anyFieldMatcherMatches("", fieldMatchersToSort, sortFile);
                 if (!rootSortFields.isEmpty() || !rootFieldMatchers.isEmpty()) {
                     sortJsonArray(jsonElement.getAsJsonArray(), rootSortFields, rootFieldMatchers);
+                    if (tracker != null) {
+                        recordSortMatches(tracker, currentPath, rootSortFields, rootFieldMatchers);
+                    }
                 }
             }
+        }
+    }
+
+    private static void recordSortMatches(SortedFieldsTracker tracker, String path,
+            List<SortField<String>> matchingPathMatchers,
+            List<SortField<Matcher<String>>> matchingFieldMatchers) {
+        if (!matchingPathMatchers.isEmpty()) {
+            tracker.recordSortedByPath(path);
+        }
+        for (SortField<Matcher<String>> fm : matchingFieldMatchers) {
+            tracker.recordSortedByPattern(path, fm.getSortFieldSelector().toString());
         }
     }
 

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/FieldsIgnorer.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/FieldsIgnorer.java
@@ -9,6 +9,7 @@
  */
 package com.github.karsaig.approvalcrest;
 
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
 import com.github.karsaig.approvalcrest.matcher.sorting.SortField;
 import com.google.gson.*;
 import org.hamcrest.Matcher;
@@ -87,6 +88,16 @@ public class FieldsIgnorer {
     }
 
     public static JsonElement findPaths(JsonElement jsonElement, Set<String> pathsToFind) {
+        return findPaths(jsonElement, pathsToFind, null, null);
+    }
+
+    /**
+     * Tracked version of findPaths. When tracker is non-null, records which fields were actually
+     * removed and why. The reasonMap maps each path to its reason (IGNORE_PATH or CUSTOM_MATCHER).
+     */
+    public static JsonElement findPaths(JsonElement jsonElement, Set<String> pathsToFind,
+                                         IgnoredFieldsTracker tracker,
+                                         Map<String, IgnoredFieldsTracker.Reason> reasonMap) {
         if (jsonElement == null || jsonElement.isJsonNull() || pathsToFind.isEmpty()) {
             return jsonElement;
         }
@@ -94,11 +105,15 @@ public class FieldsIgnorer {
         String pathToFind = headOf(pathsToFind);
         List<String> pathSegments = asList(pathToFind.split(PATH_SEPARATOR_PATTERN));
         try {
-            findPath(jsonElement, pathToFind, pathSegments);
+            boolean removed = findPath(jsonElement, pathToFind, pathSegments);
+            if (removed && tracker != null && reasonMap != null) {
+                IgnoredFieldsTracker.Reason reason = reasonMap.getOrDefault(pathToFind, IgnoredFieldsTracker.Reason.IGNORE_PATH);
+                tracker.recordIgnored(pathToFind, reason);
+            }
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(pathToFind + " does not exist", e);
         }
-        return findPaths(jsonElement, removePathFromSet(pathsToFind, pathToFind));
+        return findPaths(jsonElement, removePathFromSet(pathsToFind, pathToFind), tracker, reasonMap);
     }
 
     private static Set<String> removePathFromSet(Set<String> setToRemoveFrom, String stringToRemove) {

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/JsonElementUtil.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/JsonElementUtil.java
@@ -1,6 +1,8 @@
 package com.github.karsaig.approvalcrest;
 
 import com.github.karsaig.approvalcrest.matcher.alias.AliasMap;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -84,13 +86,18 @@ public class JsonElementUtil {
     }
 
     public static void filterByCustomMatcherPatterns(JsonElement json, MatcherConfiguration matcherConfiguration) {
+        filterByCustomMatcherPatterns(json, matcherConfiguration, null);
+    }
+
+    public static void filterByCustomMatcherPatterns(JsonElement json, MatcherConfiguration matcherConfiguration,
+                                                      IgnoredFieldsTracker tracker) {
         List<AbstractMap.SimpleEntry<Matcher<String>, Matcher<?>>> patterns = matcherConfiguration.getCustomMatcherPatterns();
         if (!patterns.isEmpty()) {
             List<Matcher<String>> patternKeys = new ArrayList<>();
             for (AbstractMap.SimpleEntry<Matcher<String>, Matcher<?>> entry : patterns) {
                 patternKeys.add(entry.getKey());
             }
-            filterByFieldMatchers(json, patternKeys);
+            filterByFieldMatchers(json, patternKeys, tracker, IgnoredFieldsTracker.Reason.CUSTOM_MATCHER_PATTERN);
         }
     }
 
@@ -125,27 +132,43 @@ public class JsonElementUtil {
     }
 
     public static void filterByFieldMatchers(JsonElement jsonElement, List<Matcher<String>> matchers) {
+        filterByFieldMatchers(jsonElement, matchers, null, null);
+    }
+
+    public static void filterByFieldMatchers(JsonElement jsonElement, List<Matcher<String>> matchers,
+                                              IgnoredFieldsTracker tracker, IgnoredFieldsTracker.Reason reason) {
         if (jsonElement != null && !matchers.isEmpty() && !jsonElement.isJsonNull()) {
-            filterFieldsByFieldMatchers(jsonElement, matchers);
+            filterFieldsByFieldMatchers(jsonElement, matchers, tracker, reason, "");
         }
     }
 
-    private static boolean filterFieldsByFieldMatchers(JsonElement jsonElement, List<Matcher<String>> matchers) {
+    private static boolean filterFieldsByFieldMatchers(JsonElement jsonElement, List<Matcher<String>> matchers,
+                                                        IgnoredFieldsTracker tracker, IgnoredFieldsTracker.Reason reason,
+                                                        String currentPath) {
         if (jsonElement.isJsonObject()) {
             JsonObject jsonObject = jsonElement.getAsJsonObject();
             boolean changes = false;
             Iterator<Map.Entry<String, JsonElement>> iter = jsonObject.entrySet().iterator();
             while (iter.hasNext()) {
                 Map.Entry<String, JsonElement> entry = iter.next();
-                if (anyMatchesFieldName(entry.getKey(), matchers)) {
+                Matcher<String> matchedPattern = findMatchingPattern(entry.getKey(), matchers);
+                if (matchedPattern != null) {
                     iter.remove();
-                    changes |= true;
+                    changes = true;
+                    if (tracker != null && reason != null) {
+                        String childPath = currentPath.isEmpty() ? entry.getKey() : currentPath + "." + entry.getKey();
+                        tracker.recordIgnoredPattern(childPath, reason, matchedPattern.toString());
+                    }
                 } else {
                     JsonElement je = entry.getValue();
-                    boolean changed = filterFieldsByFieldMatchers(je, matchers);
+                    String childPath = tracker != null ? (currentPath.isEmpty() ? entry.getKey() : currentPath + "." + entry.getKey()) : "";
+                    boolean changed = filterFieldsByFieldMatchers(je, matchers, tracker, reason, childPath);
                     if (changed && isEmpty(je)) {
                         iter.remove();
-                        changes |= true;
+                        changes = true;
+                        if (tracker != null) {
+                            tracker.recordRemovedEmpty(childPath, collectChildPaths(tracker, childPath));
+                        }
                     }
                 }
             }
@@ -154,17 +177,42 @@ public class JsonElementUtil {
             JsonArray jsonArray = jsonElement.getAsJsonArray();
             Iterator<JsonElement> iterator = jsonArray.iterator();
             boolean changes = false;
+            int idx = 0;
             while (iterator.hasNext()) {
                 JsonElement je = iterator.next();
-                boolean changed = filterFieldsByFieldMatchers(je, matchers);
+                String elemPath = tracker != null ? currentPath + "[" + idx + "]" : "";
+                boolean changed = filterFieldsByFieldMatchers(je, matchers, tracker, reason, elemPath);
                 if (changed && isEmpty(je)) {
                     iterator.remove();
-                    changes |= true;
+                    changes = true;
+                } else {
+                    idx++;
                 }
             }
             return changes;
         }
         return false;
+    }
+
+    private static Matcher<String> findMatchingPattern(String fieldName, List<Matcher<String>> matchers) {
+        for (Matcher<String> matcher : matchers) {
+            if (matcher.matches(fieldName)) {
+                return matcher;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> collectChildPaths(IgnoredFieldsTracker tracker, String parentPath) {
+        List<String> causes = new ArrayList<>();
+        String prefix = parentPath + ".";
+        for (IgnoredFieldsTracker.IgnoredField field : tracker.getFields()) {
+            if (field.getPath().startsWith(prefix)) {
+                String desc = field.getPath() + " (" + field.getReason() + ")";
+                causes.add(desc);
+            }
+        }
+        return causes;
     }
 
     public static List<JsonElement> collectValuesByFieldNamePattern(JsonElement root, Matcher<String> fieldNamePattern) {
@@ -197,11 +245,15 @@ public class JsonElementUtil {
      * The last registered matching entry in the map wins.
      */
     public static void applyAliases(JsonElement root, AliasMap aliases) {
-        applyAliasesRecursive(root, aliases, "", null);
+        applyAliasesRecursive(root, aliases, "", null, null);
+    }
+
+    public static void applyAliases(JsonElement root, AliasMap aliases, AliasTracker tracker) {
+        applyAliasesRecursive(root, aliases, "", null, tracker);
     }
 
     private static void applyAliasesRecursive(JsonElement element, AliasMap aliases,
-                                               String currentPath, String fieldName) {
+                                               String currentPath, String fieldName, AliasTracker tracker) {
         if (element == null || element.isJsonNull()) {
             return;
         }
@@ -218,10 +270,13 @@ public class JsonElementUtil {
                         Optional<String> alias = aliases.resolve(childPath, childField, coerced);
                         if (alias.isPresent()) {
                             obj.addProperty(childField, alias.get());
+                            if (tracker != null) {
+                                tracker.recordAlias(childPath, coerced, alias.get());
+                            }
                         }
                     }
                 } else {
-                    applyAliasesRecursive(child, aliases, childPath, childField);
+                    applyAliasesRecursive(child, aliases, childPath, childField, tracker);
                 }
             }
         } else if (element.isJsonArray()) {
@@ -232,14 +287,16 @@ public class JsonElementUtil {
                     JsonPrimitive prim = child.getAsJsonPrimitive();
                     if (!prim.isBoolean()) {
                         String coerced = prim.getAsString();
-                        // for array elements, fieldName is the array's own field name
                         Optional<String> alias = aliases.resolve(currentPath, fieldName != null ? fieldName : "", coerced);
                         if (alias.isPresent()) {
                             arr.set(i, new JsonPrimitive(alias.get()));
+                            if (tracker != null) {
+                                tracker.recordAlias(currentPath + "[" + i + "]", coerced, alias.get());
+                            }
                         }
                     }
                 } else {
-                    applyAliasesRecursive(child, aliases, currentPath, fieldName);
+                    applyAliasesRecursive(child, aliases, currentPath, fieldName, tracker);
                 }
             }
         }

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/AbstractDiagnosingMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/AbstractDiagnosingMatcher.java
@@ -5,6 +5,8 @@ import com.github.karsaig.approvalcrest.ComparisonDescription;
 import com.github.karsaig.approvalcrest.Either;
 import com.github.karsaig.approvalcrest.MatcherConfiguration;
 import com.github.karsaig.approvalcrest.PathNullPointerException;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import org.hamcrest.Description;
@@ -109,7 +111,33 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
         return true;
     }
 
+    protected boolean assertJsonEquals(String expectedJson, String actualJson, Description mismatchDescription,
+                                        Function<Throwable, String> messageExtractor,
+                                        IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker, String note) {
+        try {
+            JSONAssert.assertEquals(expectedJson, actualJson, true);
+        } catch (AssertionError | JSONException e) {
+            return appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, actualJson, messageExtractor.apply(e),
+                    ignoredTracker, aliasTracker, note);
+        }
+        return true;
+    }
+
     protected boolean appendMismatchDescription(Description mismatchDescription, String expected, String actual, String message) {
+        return appendMismatchDescription(mismatchDescription, expected, actual, message, null, null, false);
+    }
+
+    protected boolean appendMismatchDescription(Description mismatchDescription, String expected, String actual,
+                                                 String message, IgnoredFieldsTracker ignoredFieldsTracker,
+                                                 AliasTracker aliasTracker, boolean typesIgnoredConfigured) {
+        return appendMismatchDescriptionWithNote(mismatchDescription, expected, actual, message,
+                ignoredFieldsTracker, aliasTracker,
+                typesIgnoredConfigured ? "Type-based ignoring is configured but field-level tracking is not available for it." : null);
+    }
+
+    protected boolean appendMismatchDescriptionWithNote(Description mismatchDescription, String expected, String actual,
+                                                         String message, IgnoredFieldsTracker ignoredFieldsTracker,
+                                                         AliasTracker aliasTracker, String note) {
         if (comparisonDescriptionNeeded && ComparisonDescription.class.isInstance(mismatchDescription)) {
             ComparisonDescription shazamMismatchDescription = (ComparisonDescription) mismatchDescription;
             shazamMismatchDescription.setComparisonFailure(true);
@@ -117,6 +145,11 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
             shazamMismatchDescription.setActual(actual);
             shazamMismatchDescription.setDifferencesMessage(message);
             shazamMismatchDescription.setMachineReadable(machineReadableOutput);
+            shazamMismatchDescription.setIgnoredFieldsTracker(ignoredFieldsTracker);
+            shazamMismatchDescription.setAliasTracker(aliasTracker);
+            if (note != null) {
+                shazamMismatchDescription.setNote(note);
+            }
         }
         mismatchDescription.appendText(message);
         return false;
@@ -128,6 +161,22 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
 
     protected boolean isComparisonDescriptionNeeded() {
         return comparisonDescriptionNeeded;
+    }
+
+    protected String buildUntrackedNote(MatcherConfiguration config) {
+        if (!machineReadableOutput) {
+            return null;
+        }
+        boolean hasTypes = !config.getTypesToIgnore().isEmpty();
+        boolean hasPatterns = !config.getPatternsToIgnore().isEmpty();
+        if (hasTypes && hasPatterns) {
+            return "Type-based and pattern-based ignoring are configured but field-level tracking is not available for them.";
+        } else if (hasTypes) {
+            return "Type-based ignoring is configured but field-level tracking is not available for it.";
+        } else if (hasPatterns) {
+            return "Pattern-based ignoring is configured but field-level tracking is not available for it.";
+        }
+        return null;
     }
 
     protected boolean areCustomMatchersMatchingBeanOrJson(Object actual, JsonElement actualAsJsonElement, Description mismatchDescription, Gson gson, MatcherConfiguration matcherConfiguration) {

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/AbstractDiagnosingMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/AbstractDiagnosingMatcher.java
@@ -7,6 +7,7 @@ import com.github.karsaig.approvalcrest.MatcherConfiguration;
 import com.github.karsaig.approvalcrest.PathNullPointerException;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.SortedFieldsTracker;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import org.hamcrest.Description;
@@ -113,12 +114,13 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
 
     protected boolean assertJsonEquals(String expectedJson, String actualJson, Description mismatchDescription,
                                         Function<Throwable, String> messageExtractor,
-                                        IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker, String note) {
+                                        IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker,
+                                        SortedFieldsTracker sortedTracker, String note) {
         try {
             JSONAssert.assertEquals(expectedJson, actualJson, true);
         } catch (AssertionError | JSONException e) {
             return appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, actualJson, messageExtractor.apply(e),
-                    ignoredTracker, aliasTracker, note);
+                    ignoredTracker, aliasTracker, sortedTracker, note);
         }
         return true;
     }
@@ -131,13 +133,14 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
                                                  String message, IgnoredFieldsTracker ignoredFieldsTracker,
                                                  AliasTracker aliasTracker, boolean typesIgnoredConfigured) {
         return appendMismatchDescriptionWithNote(mismatchDescription, expected, actual, message,
-                ignoredFieldsTracker, aliasTracker,
+                ignoredFieldsTracker, aliasTracker, null,
                 typesIgnoredConfigured ? "Type-based ignoring is configured but field-level tracking is not available for it." : null);
     }
 
     protected boolean appendMismatchDescriptionWithNote(Description mismatchDescription, String expected, String actual,
                                                          String message, IgnoredFieldsTracker ignoredFieldsTracker,
-                                                         AliasTracker aliasTracker, String note) {
+                                                         AliasTracker aliasTracker, SortedFieldsTracker sortedFieldsTracker,
+                                                         String note) {
         if (comparisonDescriptionNeeded && ComparisonDescription.class.isInstance(mismatchDescription)) {
             ComparisonDescription shazamMismatchDescription = (ComparisonDescription) mismatchDescription;
             shazamMismatchDescription.setComparisonFailure(true);
@@ -147,6 +150,7 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
             shazamMismatchDescription.setMachineReadable(machineReadableOutput);
             shazamMismatchDescription.setIgnoredFieldsTracker(ignoredFieldsTracker);
             shazamMismatchDescription.setAliasTracker(aliasTracker);
+            shazamMismatchDescription.setSortedFieldsTracker(sortedFieldsTracker);
             if (note != null) {
                 shazamMismatchDescription.setNote(note);
             }
@@ -167,16 +171,32 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
         if (!machineReadableOutput) {
             return null;
         }
-        boolean hasTypes = !config.getTypesToIgnore().isEmpty();
+        boolean hasTypesToIgnore = !config.getTypesToIgnore().isEmpty();
         boolean hasPatterns = !config.getPatternsToIgnore().isEmpty();
-        if (hasTypes && hasPatterns) {
-            return "Type-based and pattern-based ignoring are configured but field-level tracking is not available for them.";
-        } else if (hasTypes) {
-            return "Type-based ignoring is configured but field-level tracking is not available for it.";
-        } else if (hasPatterns) {
-            return "Pattern-based ignoring is configured but field-level tracking is not available for it.";
+        boolean hasTypesToSort = !config.getTypesToSort().isEmpty();
+
+        boolean hasIgnoreNote = hasTypesToIgnore || hasPatterns;
+        boolean hasSortNote = hasTypesToSort;
+
+        if (!hasIgnoreNote && !hasSortNote) {
+            return null;
         }
-        return null;
+
+        StringBuilder sb = new StringBuilder();
+        if (hasTypesToIgnore && hasPatterns) {
+            sb.append("Type-based and pattern-based ignoring are configured but field-level tracking is not available for them.");
+        } else if (hasTypesToIgnore) {
+            sb.append("Type-based ignoring is configured but field-level tracking is not available for it.");
+        } else if (hasPatterns) {
+            sb.append("Pattern-based ignoring is configured but field-level tracking is not available for it.");
+        }
+        if (hasSortNote) {
+            if (sb.length() > 0) {
+                sb.append(" ");
+            }
+            sb.append("Type-based sorting is configured but field-level tracking is not available for it.");
+        }
+        return sb.toString();
     }
 
     protected boolean areCustomMatchersMatchingBeanOrJson(Object actual, JsonElement actualAsJsonElement, Description mismatchDescription, Gson gson, MatcherConfiguration matcherConfiguration) {

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -14,6 +14,7 @@ import com.github.karsaig.approvalcrest.MatcherConfiguration;
 import com.github.karsaig.approvalcrest.matcher.alias.AliasMap;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.SortedFieldsTracker;
 import com.github.karsaig.approvalcrest.matcher.sorting.SortField;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -58,7 +59,7 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
     public void describeTo(Description description) {
         if(jsonDescription){
         Gson gson = gson(matcherConfiguration, circularReferenceTypes, configuration);
-        description.appendText(filterJson(gson, expected, null, null));
+        description.appendText(filterJson(gson, expected, null, null, null));
         for (String fieldPath : matcherConfiguration.getCustomMatchers().keySet()) {
             description.appendText("\nand ")
                     .appendText(fieldPath).appendText(" ")
@@ -98,18 +99,19 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
 
         IgnoredFieldsTracker ignoredTracker = machineReadableOutput ? new IgnoredFieldsTracker() : null;
         AliasTracker aliasTracker = machineReadableOutput ? new AliasTracker() : null;
+        SortedFieldsTracker sortedTracker = machineReadableOutput ? new SortedFieldsTracker() : null;
         String untrackedNote = buildUntrackedNote();
 
-        String expectedJson = filterJson(gson, expected, ignoredTracker, aliasTracker);
+        String expectedJson = filterJson(gson, expected, ignoredTracker, aliasTracker, sortedTracker);
 
         if (actual == null) {
             return appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, "null", "actual was null",
-                    ignoredTracker, aliasTracker, untrackedNote);
+                    ignoredTracker, aliasTracker, sortedTracker, untrackedNote);
         }
 
-        String actualJson = filterJson(gson, actualAsJsonElement, actual, ignoredTracker, aliasTracker);
+        String actualJson = filterJson(gson, actualAsJsonElement, actual, ignoredTracker, aliasTracker, sortedTracker);
 
-        return assertJsonEquals(expectedJson, actualJson, mismatchDescription, ignoredTracker, aliasTracker, untrackedNote);
+        return assertJsonEquals(expectedJson, actualJson, mismatchDescription, ignoredTracker, aliasTracker, sortedTracker, untrackedNote);
     }
 
 
@@ -159,22 +161,23 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
 
 
     private boolean assertJsonEquals(String expectedJson, String actualJson, Description mismatchDescription,
-                                      IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker, String note) {
+                                      IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker,
+                                      SortedFieldsTracker sortedTracker, String note) {
         try {
             org.skyscreamer.jsonassert.JSONAssert.assertEquals(expectedJson, actualJson, true);
         } catch (AssertionError | org.json.JSONException e) {
             return appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, actualJson, e.getMessage(),
-                    ignoredTracker, aliasTracker, note);
+                    ignoredTracker, aliasTracker, sortedTracker, note);
         }
         return true;
     }
 
-    private String filterJson(Gson gson, Object object, IgnoredFieldsTracker tracker, AliasTracker aliasTracker) {
-        return filterJson(gson, gson.toJsonTree(object), object, tracker, aliasTracker);
+    private String filterJson(Gson gson, Object object, IgnoredFieldsTracker tracker, AliasTracker aliasTracker, SortedFieldsTracker sortedTracker) {
+        return filterJson(gson, gson.toJsonTree(object), object, tracker, aliasTracker, sortedTracker);
     }
 
     private String filterJson(Gson gson, JsonElement preComputedJson, Object objectForTypeCheck,
-                               IgnoredFieldsTracker tracker, AliasTracker aliasTracker) {
+                               IgnoredFieldsTracker tracker, AliasTracker aliasTracker, SortedFieldsTracker sortedTracker) {
         Set<String> set = new HashSet<>();
         set.addAll(matcherConfiguration.getPathsToIgnore());
         set.addAll(matcherConfiguration.getCustomMatchers().keySet());
@@ -196,8 +199,8 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
         if (!aliasMap.isEmpty()) {
             JsonElementUtil.applyAliases(filteredJson, aliasMap, aliasTracker);
         }
-        applySorting(filteredJson, matcherConfiguration.getPathsToSort(), matcherConfiguration.getPatternsToSort(), true);
-        applyRootCollectionSorting(filteredJson, objectForTypeCheck, matcherConfiguration.getPatternsToSort(), matcherConfiguration.getPathsToSort(), matcherConfiguration.getTypesToSort());
+        applySorting(filteredJson, matcherConfiguration.getPathsToSort(), matcherConfiguration.getPatternsToSort(), true, sortedTracker);
+        applyRootCollectionSorting(filteredJson, objectForTypeCheck, matcherConfiguration.getPatternsToSort(), matcherConfiguration.getPathsToSort(), matcherConfiguration.getTypesToSort(), sortedTracker);
         return removeSetMarker(gson.toJson(filteredJson));
     }
 

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -12,14 +12,20 @@ package com.github.karsaig.approvalcrest.matcher;
 import com.github.karsaig.approvalcrest.JsonElementUtil;
 import com.github.karsaig.approvalcrest.MatcherConfiguration;
 import com.github.karsaig.approvalcrest.matcher.alias.AliasMap;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
 import com.github.karsaig.approvalcrest.matcher.sorting.SortField;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -52,7 +58,7 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
     public void describeTo(Description description) {
         if(jsonDescription){
         Gson gson = gson(matcherConfiguration, circularReferenceTypes, configuration);
-        description.appendText(filterJson(gson, expected));
+        description.appendText(filterJson(gson, expected, null, null));
         for (String fieldPath : matcherConfiguration.getCustomMatchers().keySet()) {
             description.appendText("\nand ")
                     .appendText(fieldPath).appendText(" ")
@@ -66,10 +72,13 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
         if (actual != null  && expected != null) {
             if(!skipClassComparison && !expected.getClass().isInstance(actual)){
                 if (machineReadableOutput) {
-                    mismatchDescription.appendText("FAILURE_TYPE: TYPE_MISMATCH\n"
-                            + "EXPECTED_TYPE: " + expected.getClass().getName() + "\n"
-                            + "ACTUAL_TYPE: " + actual.getClass().getName() + "\n"
-                            + "ACTION: Add .skipClassComparison() to the matcher, or set system property bMSCComparison=true");
+                    JsonObject root = new JsonObject();
+                    root.addProperty("failureType", "TYPE_MISMATCH");
+                    root.addProperty("expectedType", expected.getClass().getName());
+                    root.addProperty("actualType", actual.getClass().getName());
+                    root.addProperty("action", "Add .skipClassComparison() to the matcher, or set system property bMSCComparison=true");
+                    Gson outputGson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+                    mismatchDescription.appendText(outputGson.toJson(root));
                 } else {
                     mismatchDescription.appendText("Actual type ["+actual.getClass()+"] is not an instance of expected type ["+expected.getClass()+"]!\nThis can be ignored with skipClassComparison or\nsetting beanMatcherSkipClassComparison env variable to true");
                 }
@@ -87,15 +96,20 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
             return false;
         }
 
-        String expectedJson = filterJson(gson, expected);
+        IgnoredFieldsTracker ignoredTracker = machineReadableOutput ? new IgnoredFieldsTracker() : null;
+        AliasTracker aliasTracker = machineReadableOutput ? new AliasTracker() : null;
+        String untrackedNote = buildUntrackedNote();
+
+        String expectedJson = filterJson(gson, expected, ignoredTracker, aliasTracker);
 
         if (actual == null) {
-            return appendMismatchDescription(mismatchDescription, expectedJson, "null", "actual was null");
+            return appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, "null", "actual was null",
+                    ignoredTracker, aliasTracker, untrackedNote);
         }
 
-        String actualJson = filterJson(gson, actualAsJsonElement, actual);
+        String actualJson = filterJson(gson, actualAsJsonElement, actual, ignoredTracker, aliasTracker);
 
-        return assertEquals(expectedJson, actualJson, mismatchDescription);
+        return assertJsonEquals(expectedJson, actualJson, mismatchDescription, ignoredTracker, aliasTracker, untrackedNote);
     }
 
 
@@ -144,27 +158,51 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
     }
 
 
-    private boolean assertEquals(String expectedJson, String actualJson, Description mismatchDescription) {
-        return assertJsonEquals(expectedJson, actualJson, mismatchDescription, Throwable::getMessage);
+    private boolean assertJsonEquals(String expectedJson, String actualJson, Description mismatchDescription,
+                                      IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker, String note) {
+        try {
+            org.skyscreamer.jsonassert.JSONAssert.assertEquals(expectedJson, actualJson, true);
+        } catch (AssertionError | org.json.JSONException e) {
+            return appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, actualJson, e.getMessage(),
+                    ignoredTracker, aliasTracker, note);
+        }
+        return true;
     }
 
-    private String filterJson(Gson gson, Object object) {
-        return filterJson(gson, gson.toJsonTree(object), object);
+    private String filterJson(Gson gson, Object object, IgnoredFieldsTracker tracker, AliasTracker aliasTracker) {
+        return filterJson(gson, gson.toJsonTree(object), object, tracker, aliasTracker);
     }
 
-    private String filterJson(Gson gson, JsonElement preComputedJson, Object objectForTypeCheck) {
+    private String filterJson(Gson gson, JsonElement preComputedJson, Object objectForTypeCheck,
+                               IgnoredFieldsTracker tracker, AliasTracker aliasTracker) {
         Set<String> set = new HashSet<>();
         set.addAll(matcherConfiguration.getPathsToIgnore());
         set.addAll(matcherConfiguration.getCustomMatchers().keySet());
-        JsonElement filteredJson = findPaths(preComputedJson, set);
-        JsonElementUtil.filterByCustomMatcherPatterns(filteredJson, matcherConfiguration);
+
+        Map<String, IgnoredFieldsTracker.Reason> reasonMap = null;
+        if (tracker != null) {
+            reasonMap = new HashMap<>();
+            for (String path : matcherConfiguration.getPathsToIgnore()) {
+                reasonMap.put(path, IgnoredFieldsTracker.Reason.IGNORE_PATH);
+            }
+            for (String path : matcherConfiguration.getCustomMatchers().keySet()) {
+                reasonMap.put(path, IgnoredFieldsTracker.Reason.CUSTOM_MATCHER);
+            }
+        }
+
+        JsonElement filteredJson = findPaths(preComputedJson, set, tracker, reasonMap);
+        JsonElementUtil.filterByCustomMatcherPatterns(filteredJson, matcherConfiguration, tracker);
         AliasMap aliasMap = matcherConfiguration.getAliasMap();
         if (!aliasMap.isEmpty()) {
-            JsonElementUtil.applyAliases(filteredJson, aliasMap);
+            JsonElementUtil.applyAliases(filteredJson, aliasMap, aliasTracker);
         }
         applySorting(filteredJson, matcherConfiguration.getPathsToSort(), matcherConfiguration.getPatternsToSort(), true);
         applyRootCollectionSorting(filteredJson, objectForTypeCheck, matcherConfiguration.getPatternsToSort(), matcherConfiguration.getPathsToSort(), matcherConfiguration.getTypesToSort());
         return removeSetMarker(gson.toJson(filteredJson));
+    }
+
+    private String buildUntrackedNote() {
+        return buildUntrackedNote(matcherConfiguration);
     }
 
     @Override

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
@@ -6,6 +6,9 @@ import com.github.karsaig.approvalcrest.MatcherConfiguration;
 import com.github.karsaig.approvalcrest.matcher.alias.AliasMap;
 import com.github.karsaig.approvalcrest.matcher.file.AbstractDiagnosingFileMatcher;
 import com.github.karsaig.approvalcrest.matcher.file.FileStoreMatcherUtils;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker.Reason;
 import com.github.karsaig.approvalcrest.matcher.sorting.SortField;
 import com.google.gson.*;
 import org.hamcrest.Description;
@@ -60,7 +63,7 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
     public void describeTo(Description description) {
         Gson gson = GsonProvider.gson(matcherConfiguration, circularReferenceTypes, configuration);
         if (expected.isParsedJson()) {
-            description.appendText(filterJson(gson, expected.getParsedContent(), true, false, false));
+            description.appendText(filterJson(gson, expected.getParsedContent(), true, false, false, null, null));
         } else {
             description.appendText(expected.getOriginalContent());
         }
@@ -130,17 +133,23 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
 
         if (areCustomMatchersMatchingBeanOrJson(actual, actualJsonElement, mismatchDescription, gson, matcherConfiguration)) {
 
+            IgnoredFieldsTracker ignoredTracker = machineReadableOutput ? new IgnoredFieldsTracker() : null;
+            AliasTracker aliasTracker = machineReadableOutput ? new AliasTracker() : null;
+            String untrackedNote = buildUntrackedNote();
+
             String expectedJson = expected.getOriginalContent();
             if (expected.isParsedJson()) {
-                expectedJson = filterJson(gson, expected.getParsedContent(), fileMatcherConfig.isSortInputFile(), fileMatcherConfig.isStrictFileMatching(), fileMatcherConfig.isStrictFileMatching());
+                expectedJson = filterJson(gson, expected.getParsedContent(), fileMatcherConfig.isSortInputFile(), fileMatcherConfig.isStrictFileMatching(), fileMatcherConfig.isStrictFileMatching(), ignoredTracker, aliasTracker);
             }
 
             if (actual == null) {
-                matches = appendMismatchDescription(mismatchDescription, expectedJson, "null", "actual was null");
+                matches = appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, "null", "actual was null",
+                        ignoredTracker, aliasTracker, untrackedNote);
             } else {
-                String actualJson = filterJson(gson, actualJsonElement, true, false, false);
+                String actualJson = filterJson(gson, actualJsonElement, true, false, false, ignoredTracker, aliasTracker);
 
-                matches = assertJsonEquals(expectedJson, actualJson, mismatchDescription, e -> getAssertMessage(fileStoreMatcherUtils, e));
+                matches = assertJsonEquals(expectedJson, actualJson, mismatchDescription, e -> getAssertMessage(fileStoreMatcherUtils, e),
+                        ignoredTracker, aliasTracker, untrackedNote);
                 if (!matches) {
                     matches = handleInPlaceOverwrite(actual, gson);
                 }
@@ -191,21 +200,37 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
         });
     }
 
-    private String filterJson(Gson gson, JsonElement jsonElement, boolean sortFile, boolean skipIgnores, boolean skipCustomSortings) {
+    private String filterJson(Gson gson, JsonElement jsonElement, boolean sortFile, boolean skipIgnores, boolean skipCustomSortings,
+                              IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker) {
         Set<String> set = skipIgnores ? emptySet() : new HashSet<>(matcherConfiguration.getPathsToIgnore());
 
-        JsonElement filteredJson = findPaths(jsonElement, set);
-        JsonElementUtil.filterByFieldMatchers(filteredJson, skipIgnores ? emptyList() : matcherConfiguration.getPatternsToIgnore());
+        Map<String, Reason> reasonMap = new HashMap<>();
         if (!skipIgnores) {
-            JsonElementUtil.filterByCustomMatcherPatterns(filteredJson, matcherConfiguration);
+            for (String p : matcherConfiguration.getPathsToIgnore()) {
+                reasonMap.put(p, Reason.IGNORE_PATH);
+            }
+            for (String p : matcherConfiguration.getCustomMatchers().keySet()) {
+                reasonMap.put(p, Reason.CUSTOM_MATCHER);
+                set.add(p);
+            }
+        }
+
+        JsonElement filteredJson = findPaths(jsonElement, set, ignoredTracker, reasonMap);
+        JsonElementUtil.filterByFieldMatchers(filteredJson, skipIgnores ? emptyList() : matcherConfiguration.getPatternsToIgnore(), ignoredTracker, Reason.IGNORE_PATTERN);
+        if (!skipIgnores) {
+            JsonElementUtil.filterByCustomMatcherPatterns(filteredJson, matcherConfiguration, ignoredTracker);
         }
         AliasMap aliasMap = matcherConfiguration.getAliasMap();
         if (!aliasMap.isEmpty()) {
-            JsonElementUtil.applyAliases(filteredJson, aliasMap);
+            JsonElementUtil.applyAliases(filteredJson, aliasMap, aliasTracker);
         }
         applySorting(filteredJson, skipCustomSortings ? emptyMap() : matcherConfiguration.getPathsToSort(), skipCustomSortings ? emptyList() : matcherConfiguration.getPatternsToSort(), sortFile);
 
         return removeSetMarker(gson.toJson(filteredJson));
+    }
+
+    private String buildUntrackedNote() {
+        return buildUntrackedNote(matcherConfiguration);
     }
 
     private boolean createNotApprovedFileIfNotExists(Object toApprove, Gson gson) {
@@ -218,7 +243,7 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
 
     private String serializeToJson(Object toApprove, Gson gson) {
         JsonElement actualJsonElement = getAsJsonElement(gson, toApprove);
-        return filterJson(gson, actualJsonElement, true, false, false);
+        return filterJson(gson, actualJsonElement, true, false, false, null, null);
     }
 
     @Override

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
@@ -9,6 +9,7 @@ import com.github.karsaig.approvalcrest.matcher.file.FileStoreMatcherUtils;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker.Reason;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.SortedFieldsTracker;
 import com.github.karsaig.approvalcrest.matcher.sorting.SortField;
 import com.google.gson.*;
 import org.hamcrest.Description;
@@ -63,7 +64,7 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
     public void describeTo(Description description) {
         Gson gson = GsonProvider.gson(matcherConfiguration, circularReferenceTypes, configuration);
         if (expected.isParsedJson()) {
-            description.appendText(filterJson(gson, expected.getParsedContent(), true, false, false, null, null));
+            description.appendText(filterJson(gson, expected.getParsedContent(), true, false, false, null, null, null));
         } else {
             description.appendText(expected.getOriginalContent());
         }
@@ -135,21 +136,22 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
 
             IgnoredFieldsTracker ignoredTracker = machineReadableOutput ? new IgnoredFieldsTracker() : null;
             AliasTracker aliasTracker = machineReadableOutput ? new AliasTracker() : null;
+            SortedFieldsTracker sortedTracker = machineReadableOutput ? new SortedFieldsTracker() : null;
             String untrackedNote = buildUntrackedNote();
 
             String expectedJson = expected.getOriginalContent();
             if (expected.isParsedJson()) {
-                expectedJson = filterJson(gson, expected.getParsedContent(), fileMatcherConfig.isSortInputFile(), fileMatcherConfig.isStrictFileMatching(), fileMatcherConfig.isStrictFileMatching(), ignoredTracker, aliasTracker);
+                expectedJson = filterJson(gson, expected.getParsedContent(), fileMatcherConfig.isSortInputFile(), fileMatcherConfig.isStrictFileMatching(), fileMatcherConfig.isStrictFileMatching(), ignoredTracker, aliasTracker, sortedTracker);
             }
 
             if (actual == null) {
                 matches = appendMismatchDescriptionWithNote(mismatchDescription, expectedJson, "null", "actual was null",
-                        ignoredTracker, aliasTracker, untrackedNote);
+                        ignoredTracker, aliasTracker, sortedTracker, untrackedNote);
             } else {
-                String actualJson = filterJson(gson, actualJsonElement, true, false, false, ignoredTracker, aliasTracker);
+                String actualJson = filterJson(gson, actualJsonElement, true, false, false, ignoredTracker, aliasTracker, sortedTracker);
 
                 matches = assertJsonEquals(expectedJson, actualJson, mismatchDescription, e -> getAssertMessage(fileStoreMatcherUtils, e),
-                        ignoredTracker, aliasTracker, untrackedNote);
+                        ignoredTracker, aliasTracker, sortedTracker, untrackedNote);
                 if (!matches) {
                     matches = handleInPlaceOverwrite(actual, gson);
                 }
@@ -201,7 +203,7 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
     }
 
     private String filterJson(Gson gson, JsonElement jsonElement, boolean sortFile, boolean skipIgnores, boolean skipCustomSortings,
-                              IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker) {
+                              IgnoredFieldsTracker ignoredTracker, AliasTracker aliasTracker, SortedFieldsTracker sortedTracker) {
         Set<String> set = skipIgnores ? emptySet() : new HashSet<>(matcherConfiguration.getPathsToIgnore());
 
         Map<String, Reason> reasonMap = new HashMap<>();
@@ -224,7 +226,7 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
         if (!aliasMap.isEmpty()) {
             JsonElementUtil.applyAliases(filteredJson, aliasMap, aliasTracker);
         }
-        applySorting(filteredJson, skipCustomSortings ? emptyMap() : matcherConfiguration.getPathsToSort(), skipCustomSortings ? emptyList() : matcherConfiguration.getPatternsToSort(), sortFile);
+        applySorting(filteredJson, skipCustomSortings ? emptyMap() : matcherConfiguration.getPathsToSort(), skipCustomSortings ? emptyList() : matcherConfiguration.getPatternsToSort(), sortFile, sortedTracker);
 
         return removeSetMarker(gson.toJson(filteredJson));
     }
@@ -243,7 +245,7 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
 
     private String serializeToJson(Object toApprove, Gson gson) {
         JsonElement actualJsonElement = getAsJsonElement(gson, toApprove);
-        return filterJson(gson, actualJsonElement, true, false, false, null, null);
+        return filterJson(gson, actualJsonElement, true, false, false, null, null, null);
     }
 
     @Override

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
@@ -18,16 +18,22 @@ import com.github.karsaig.approvalcrest.ComparisonDescription;
 import com.github.karsaig.approvalcrest.FileMatcherConfig;
 import com.github.karsaig.approvalcrest.matcher.AbstractDiagnosingMatcher;
 import com.github.karsaig.approvalcrest.matcher.TestMetaInformation;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
 
 import org.hamcrest.Description;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Supplier;
 import com.google.common.hash.Hashing;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 
 public abstract class AbstractDiagnosingFileMatcher<T, U extends AbstractDiagnosingFileMatcher<T, U>> extends AbstractDiagnosingMatcher<T> implements ApprovedFileMatcher<U> {
 
+    private static final Gson JSON_OUTPUT_GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     public static final int NUM_OF_HASH_CHARS = 6;
     protected final FileStoreMatcherUtils fileStoreMatcherUtils;
     protected final FileMatcherConfig fileMatcherConfig;
@@ -151,13 +157,27 @@ public abstract class AbstractDiagnosingFileMatcher<T, U extends AbstractDiagnos
     @Override
     protected boolean appendMismatchDescription(Description mismatchDescription, String expected, String actual, String message) {
         boolean result = super.appendMismatchDescription(mismatchDescription, expected, actual, message);
+        setFileInfoOnDescription(mismatchDescription);
+        return result;
+    }
+
+    @Override
+    protected boolean appendMismatchDescriptionWithNote(Description mismatchDescription, String expected, String actual,
+                                                         String message, IgnoredFieldsTracker ignoredFieldsTracker,
+                                                         AliasTracker aliasTracker, String note) {
+        boolean result = super.appendMismatchDescriptionWithNote(mismatchDescription, expected, actual, message,
+                ignoredFieldsTracker, aliasTracker, note);
+        setFileInfoOnDescription(mismatchDescription);
+        return result;
+    }
+
+    private void setFileInfoOnDescription(Description mismatchDescription) {
         if (machineReadableOutput && mismatchDescription instanceof ComparisonDescription && fileNameWithPath != null) {
             ComparisonDescription comparisonDescription = (ComparisonDescription) mismatchDescription;
             Path approvedFile = fileStoreMatcherUtils.getApproved(fileNameWithPath, filenameWithRelativePath).getFileName();
             comparisonDescription.setApprovedFilePath(approvedFile.toAbsolutePath().toString());
             comparisonDescription.setTestInfo(testClassName + "#" + testMethodName);
         }
-        return result;
     }
 
     @SuppressWarnings("deprecation")
@@ -196,11 +216,13 @@ public abstract class AbstractDiagnosingFileMatcher<T, U extends AbstractDiagnos
                 FileStoreMatcherUtils.CreatedFile createdFileAndInfo = fileStoreMatcherUtils.createNotApproved(fileNameWithPath,filenameWithRelativePath, content.get(), getCommentLine());
                 String message;
                 if (machineReadableOutput) {
-                    message = "FAILURE_TYPE: NEW_FILE\n"
-                            + "TEST: " + testClassName + "#" + testMethodName + "\n"
-                            + "Not approved file created: '" + createdFileAndInfo.getFileName().toAbsolutePath() + "';\n"
-                            + "APPROVE_TO: " + approvedFileAndInfo.getFileName().toAbsolutePath() + "\n"
-                            + "ACTION: Set system property fMUInPlace=true and re-run, or copy the not-approved file to APPROVE_TO path above";
+                    JsonObject json = new JsonObject();
+                    json.addProperty("failureType", "NEW_FILE");
+                    json.addProperty("test", testClassName + "#" + testMethodName);
+                    json.addProperty("notApprovedFile", createdFileAndInfo.getFileName().toAbsolutePath().toString());
+                    json.addProperty("approveTo", approvedFileAndInfo.getFileName().toAbsolutePath().toString());
+                    json.addProperty("action", "Set system property fMUInPlace=true and re-run, or copy the not-approved file to approveTo path above");
+                    message = JSON_OUTPUT_GSON.toJson(json);
                 } else {
                     message = "Not approved file created: '" + createdFileAndInfo.getFileNameWithRelativePath()
                             + "';\n please verify its contents and rename it to '" + approvedFileAndInfo.getFileName().getFileName() + "'.";

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
@@ -20,6 +20,7 @@ import com.github.karsaig.approvalcrest.matcher.AbstractDiagnosingMatcher;
 import com.github.karsaig.approvalcrest.matcher.TestMetaInformation;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.AliasTracker;
 import com.github.karsaig.approvalcrest.matcher.machinereadable.IgnoredFieldsTracker;
+import com.github.karsaig.approvalcrest.matcher.machinereadable.SortedFieldsTracker;
 
 import org.hamcrest.Description;
 
@@ -164,9 +165,10 @@ public abstract class AbstractDiagnosingFileMatcher<T, U extends AbstractDiagnos
     @Override
     protected boolean appendMismatchDescriptionWithNote(Description mismatchDescription, String expected, String actual,
                                                          String message, IgnoredFieldsTracker ignoredFieldsTracker,
-                                                         AliasTracker aliasTracker, String note) {
+                                                         AliasTracker aliasTracker, SortedFieldsTracker sortedFieldsTracker,
+                                                         String note) {
         boolean result = super.appendMismatchDescriptionWithNote(mismatchDescription, expected, actual, message,
-                ignoredFieldsTracker, aliasTracker, note);
+                ignoredFieldsTracker, aliasTracker, sortedFieldsTracker, note);
         setFileInfoOnDescription(mismatchDescription);
         return result;
     }

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/AliasTracker.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/AliasTracker.java
@@ -1,0 +1,50 @@
+package com.github.karsaig.approvalcrest.matcher.machinereadable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Accumulates records of values that were replaced by aliases during JSON processing.
+ * Only instantiated when machine-readable output is enabled.
+ */
+public class AliasTracker {
+
+    public static class AliasedField {
+        private final String path;
+        private final String originalValue;
+        private final String alias;
+
+        public AliasedField(String path, String originalValue, String alias) {
+            this.path = path;
+            this.originalValue = originalValue;
+            this.alias = alias;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getOriginalValue() {
+            return originalValue;
+        }
+
+        public String getAlias() {
+            return alias;
+        }
+    }
+
+    private final List<AliasedField> fields = new ArrayList<>();
+
+    public void recordAlias(String path, String originalValue, String alias) {
+        fields.add(new AliasedField(path, originalValue, alias));
+    }
+
+    public List<AliasedField> getFields() {
+        return Collections.unmodifiableList(fields);
+    }
+
+    public boolean isEmpty() {
+        return fields.isEmpty();
+    }
+}

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/IgnoredFieldsTracker.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/IgnoredFieldsTracker.java
@@ -1,0 +1,84 @@
+package com.github.karsaig.approvalcrest.matcher.machinereadable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Accumulates records of fields that were actually removed during JSON filtering.
+ * Only instantiated when machine-readable output is enabled.
+ */
+public class IgnoredFieldsTracker {
+
+    public enum Reason {
+        IGNORE_PATH,
+        IGNORE_PATTERN,
+        CUSTOM_MATCHER,
+        CUSTOM_MATCHER_PATTERN,
+        REMOVED_EMPTY
+    }
+
+    public static class IgnoredField {
+        private final String path;
+        private final Reason reason;
+        private final String pattern;
+        private final List<String> causes;
+
+        private IgnoredField(String path, Reason reason, String pattern, List<String> causes) {
+            this.path = path;
+            this.reason = reason;
+            this.pattern = pattern;
+            this.causes = causes;
+        }
+
+        public static IgnoredField of(String path, Reason reason) {
+            return new IgnoredField(path, reason, null, null);
+        }
+
+        public static IgnoredField ofPattern(String path, Reason reason, String pattern) {
+            return new IgnoredField(path, reason, pattern, null);
+        }
+
+        public static IgnoredField removedEmpty(String path, List<String> causes) {
+            return new IgnoredField(path, Reason.REMOVED_EMPTY, null, causes);
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public Reason getReason() {
+            return reason;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public List<String> getCauses() {
+            return causes;
+        }
+    }
+
+    private final List<IgnoredField> fields = new ArrayList<>();
+
+    public void recordIgnored(String path, Reason reason) {
+        fields.add(IgnoredField.of(path, reason));
+    }
+
+    public void recordIgnoredPattern(String path, Reason reason, String patternDescription) {
+        fields.add(IgnoredField.ofPattern(path, reason, patternDescription));
+    }
+
+    public void recordRemovedEmpty(String path, List<String> causes) {
+        fields.add(IgnoredField.removedEmpty(path, causes));
+    }
+
+    public List<IgnoredField> getFields() {
+        return Collections.unmodifiableList(fields);
+    }
+
+    public boolean isEmpty() {
+        return fields.isEmpty();
+    }
+}

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/SortedFieldsTracker.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/SortedFieldsTracker.java
@@ -1,0 +1,67 @@
+package com.github.karsaig.approvalcrest.matcher.machinereadable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Accumulates records of fields whose arrays were actually sorted due to user-configured sorting.
+ * Only instantiated when machine-readable output is enabled.
+ */
+public class SortedFieldsTracker {
+
+    public enum Reason {
+        SORT_PATH,
+        SORT_PATTERN
+    }
+
+    public static class SortedField {
+        private final String path;
+        private final Reason reason;
+        private final String pattern;
+
+        private SortedField(String path, Reason reason, String pattern) {
+            this.path = path;
+            this.reason = reason;
+            this.pattern = pattern;
+        }
+
+        public static SortedField ofPath(String path) {
+            return new SortedField(path, Reason.SORT_PATH, null);
+        }
+
+        public static SortedField ofPattern(String path, String patternDescription) {
+            return new SortedField(path, Reason.SORT_PATTERN, patternDescription);
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public Reason getReason() {
+            return reason;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+    }
+
+    private final List<SortedField> fields = new ArrayList<>();
+
+    public void recordSortedByPath(String path) {
+        fields.add(SortedField.ofPath(path));
+    }
+
+    public void recordSortedByPattern(String path, String patternDescription) {
+        fields.add(SortedField.ofPattern(path, patternDescription));
+    }
+
+    public List<SortedField> getFields() {
+        return Collections.unmodifiableList(fields);
+    }
+
+    public boolean isEmpty() {
+        return fields.isEmpty();
+    }
+}

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractFileMatcherTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractFileMatcherTest.java
@@ -286,11 +286,13 @@ public abstract class AbstractFileMatcherTest extends AbstractTest {
     }
 
     protected String getMachineReadableNotApprovedCreationMessage(Path notApprovedAbsolutePath, Path approvedAbsolutePath) {
-        return "FAILURE_TYPE: NEW_FILE\n"
-                + "TEST: dummyTestClassName#dummyTestMethodName\n"
-                + "Not approved file created: '" + notApprovedAbsolutePath.toAbsolutePath() + "';\n"
-                + "APPROVE_TO: " + approvedAbsolutePath.toAbsolutePath() + "\n"
-                + "ACTION: Set system property fMUInPlace=true and re-run, or copy the not-approved file to APPROVE_TO path above";
+        com.google.gson.JsonObject json = new com.google.gson.JsonObject();
+        json.addProperty("failureType", "NEW_FILE");
+        json.addProperty("test", "dummyTestClassName#dummyTestMethodName");
+        json.addProperty("notApprovedFile", notApprovedAbsolutePath.toAbsolutePath().toString());
+        json.addProperty("approveTo", approvedAbsolutePath.toAbsolutePath().toString());
+        json.addProperty("action", "Set system property fMUInPlace=true and re-run, or copy the not-approved file to approveTo path above");
+        return new com.google.gson.GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(json);
     }
 
     protected void writeFile(Path path, String content) {

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/BeanMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/BeanMatcherMachineReadableTest.java
@@ -5,12 +5,14 @@ import com.github.karsaig.approvalcrest.matcher.AbstractTest;
 import com.github.karsaig.approvalcrest.matcher.DiagnosingCustomisableMatcher;
 import com.github.karsaig.approvalcrest.matcher.TestMatcherFactory;
 import com.github.karsaig.approvalcrest.testdata.BeanWithPrimitives;
+import com.github.karsaig.approvalcrest.testdata.ParentBean;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
 import static com.github.karsaig.approvalcrest.testdata.BeanWithPrimitives.Builder.beanWithPrimitives;
+import static com.github.karsaig.approvalcrest.testdata.ParentBean.Builder.parent;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BeanMatcherMachineReadableTest extends AbstractTest {
@@ -37,6 +39,7 @@ public class BeanMatcherMachineReadableTest extends AbstractTest {
                 () -> assertTrue(json.has("actual"), "Should contain actual field"),
                 () -> assertTrue(json.has("ignoredFields"), "Should contain ignoredFields array"),
                 () -> assertTrue(json.has("aliasedFields"), "Should contain aliasedFields array"),
+                () -> assertTrue(json.has("sortedFields"), "Should contain sortedFields array"),
                 () -> assertFalse(json.has("approvedFile"), "Should NOT contain approvedFile for bean matchers"),
                 () -> assertTrue(error.isExpectedDefined(), "Expected must be defined for IDE diff view"),
                 () -> assertTrue(error.isActualDefined(), "Actual must be defined for IDE diff view"),
@@ -184,5 +187,90 @@ public class BeanMatcherMachineReadableTest extends AbstractTest {
         assertTrue(json.has("note"), "Should contain note when type-based ignoring is configured");
         assertTrue(json.get("note").getAsString().contains("Type-based ignoring"),
                 "Note should mention type-based ignoring");
+    }
+
+    @Test
+    public void shouldTrackSortedFieldsByPathInMachineReadableOutput() {
+        ParentBean expected = parent().parentString("expected").addToChildBeanList("b", 2).addToChildBeanList("a", 1).build();
+        ParentBean actual = parent().parentString("actual").addToChildBeanList("a", 1).addToChildBeanList("b", 2).build();
+
+        DiagnosingCustomisableMatcher<ParentBean> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .sortField("childBeanList")
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        com.google.gson.JsonArray sortedFields = json.getAsJsonArray("sortedFields");
+        assertTrue(sortedFields.size() > 0, "sortedFields should not be empty when sorting is applied");
+
+        JsonObject firstSorted = sortedFields.get(0).getAsJsonObject();
+        assertEquals("childBeanList", firstSorted.get("path").getAsString());
+        assertEquals("SORT_PATH", firstSorted.get("reason").getAsString());
+    }
+
+    @Test
+    public void shouldTrackSortedFieldsByPatternInMachineReadableOutput() {
+        ParentBean expected = parent().parentString("expected").addToChildBeanList("b", 2).addToChildBeanList("a", 1).build();
+        ParentBean actual = parent().parentString("actual").addToChildBeanList("a", 1).addToChildBeanList("b", 2).build();
+
+        DiagnosingCustomisableMatcher<ParentBean> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .sortField(org.hamcrest.Matchers.containsString("childBean"))
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        com.google.gson.JsonArray sortedFields = json.getAsJsonArray("sortedFields");
+        assertTrue(sortedFields.size() > 0, "sortedFields should not be empty when pattern sort is applied");
+
+        JsonObject firstSorted = sortedFields.get(0).getAsJsonObject();
+        assertEquals("childBeanList", firstSorted.get("path").getAsString());
+        assertEquals("SORT_PATTERN", firstSorted.get("reason").getAsString());
+        assertTrue(firstSorted.has("pattern"), "Should include pattern description");
+    }
+
+    @Test
+    public void shouldShowEmptySortedFieldsWhenNoSortingConfigured() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanBoolean(false).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanBoolean(true).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        assertTrue(json.has("sortedFields"), "Should always contain sortedFields array");
+        assertEquals(0, json.getAsJsonArray("sortedFields").size(), "sortedFields should be empty when no sorting configured");
+    }
+
+    @Test
+    public void shouldIncludeNoteWhenTypeSortingConfigured() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanBoolean(false).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanBoolean(true).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .sortType(String.class)
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        assertTrue(json.has("note"), "Should contain note when type-based sorting is configured");
+        assertTrue(json.get("note").getAsString().contains("Type-based sorting"),
+                "Note should mention type-based sorting");
     }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/BeanMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/BeanMatcherMachineReadableTest.java
@@ -5,6 +5,8 @@ import com.github.karsaig.approvalcrest.matcher.AbstractTest;
 import com.github.karsaig.approvalcrest.matcher.DiagnosingCustomisableMatcher;
 import com.github.karsaig.approvalcrest.matcher.TestMatcherFactory;
 import com.github.karsaig.approvalcrest.testdata.BeanWithPrimitives;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
@@ -28,13 +30,14 @@ public class BeanMatcherMachineReadableTest extends AbstractTest {
                 () -> assertThat(actual, underTest));
 
         String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
         assertAll(
-                () -> assertTrue(msg.contains("FAILURE_TYPE: MISMATCH"), "Should contain failure type header"),
-                () -> assertTrue(msg.contains("=== EXPECTED (full) ==="), "Should contain EXPECTED block start"),
-                () -> assertTrue(msg.contains("=== END EXPECTED ==="), "Should contain EXPECTED block end"),
-                () -> assertTrue(msg.contains("=== ACTUAL (full) ==="), "Should contain ACTUAL block start"),
-                () -> assertTrue(msg.contains("=== END ACTUAL ==="), "Should contain ACTUAL block end"),
-                () -> assertFalse(msg.contains("APPROVED_FILE:"), "Should NOT contain approved file path label for bean matchers"),
+                () -> assertEquals("MISMATCH", json.get("failureType").getAsString(), "Should contain failureType"),
+                () -> assertTrue(json.has("expected"), "Should contain expected field"),
+                () -> assertTrue(json.has("actual"), "Should contain actual field"),
+                () -> assertTrue(json.has("ignoredFields"), "Should contain ignoredFields array"),
+                () -> assertTrue(json.has("aliasedFields"), "Should contain aliasedFields array"),
+                () -> assertFalse(json.has("approvedFile"), "Should NOT contain approvedFile for bean matchers"),
                 () -> assertTrue(error.isExpectedDefined(), "Expected must be defined for IDE diff view"),
                 () -> assertTrue(error.isActualDefined(), "Actual must be defined for IDE diff view"),
                 () -> assertNotNull(error.getExpected().getValue(), "Expected value must be non-null for IDE diff view"),
@@ -55,8 +58,8 @@ public class BeanMatcherMachineReadableTest extends AbstractTest {
 
         String msg = error.getMessage();
         assertAll(
-                () -> assertFalse(msg.contains("=== EXPECTED (full) ==="), "Should NOT contain machine-readable EXPECTED block"),
-                () -> assertFalse(msg.contains("=== ACTUAL (full) ==="), "Should NOT contain machine-readable ACTUAL block")
+                () -> assertFalse(msg.contains("\"failureType\""), "Should NOT contain JSON failureType field"),
+                () -> assertFalse(msg.contains("\"expected\""), "Should NOT contain JSON expected field")
         );
     }
 
@@ -67,5 +70,119 @@ public class BeanMatcherMachineReadableTest extends AbstractTest {
         String message = desc.toFailureMessage("some reason");
         assertTrue(message.endsWith(AI_TIP_SUFFIX),
                 "Non-machine-readable failure message must end with AI discovery tip. Got: " + message);
+    }
+
+    @Test
+    public void shouldTrackIgnoredPathsInMachineReadableOutput() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanBoolean(false).beanInt(99).beanLong(5L).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanBoolean(true).beanInt(42).beanLong(5L).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .ignoring("beanBoolean")
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        com.google.gson.JsonArray ignoredFields = json.getAsJsonArray("ignoredFields");
+        assertTrue(ignoredFields.size() > 0, "ignoredFields should not be empty when a field was actually ignored");
+
+        JsonObject firstIgnored = ignoredFields.get(0).getAsJsonObject();
+        assertEquals("beanBoolean", firstIgnored.get("path").getAsString());
+        assertEquals("IGNORE_PATH", firstIgnored.get("reason").getAsString());
+    }
+
+    @Test
+    public void shouldShowEmptyIgnoredFieldsWhenConfiguredButNothingRemoved() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanBoolean(true).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanBoolean(false).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .ignoring("nonExistentField")
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        com.google.gson.JsonArray ignoredFields = json.getAsJsonArray("ignoredFields");
+        assertEquals(0, ignoredFields.size(), "ignoredFields should be empty when configured path doesn't exist in data");
+    }
+
+    @Test
+    public void shouldTrackCustomMatcherPathInIgnoredFields() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanInt(99).beanBoolean(false).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanInt(42).beanBoolean(true).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .with("beanInteger", org.hamcrest.Matchers.equalTo(42))
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        com.google.gson.JsonArray ignoredFields = json.getAsJsonArray("ignoredFields");
+
+        boolean foundCustomMatcher = false;
+        for (int i = 0; i < ignoredFields.size(); i++) {
+            JsonObject entry = ignoredFields.get(i).getAsJsonObject();
+            if ("beanInteger".equals(entry.get("path").getAsString())
+                    && "CUSTOM_MATCHER".equals(entry.get("reason").getAsString())) {
+                foundCustomMatcher = true;
+                break;
+            }
+        }
+        assertTrue(foundCustomMatcher, "Should track beanInteger as CUSTOM_MATCHER in ignoredFields");
+    }
+
+    @Test
+    public void shouldTrackAliasedFieldsInMachineReadableOutput() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanInt(99).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanInt(42).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .withAlias("99", "EXPECTED_VALUE")
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        com.google.gson.JsonArray aliasedFields = json.getAsJsonArray("aliasedFields");
+        assertTrue(aliasedFields.size() > 0, "aliasedFields should not be empty when aliases are applied");
+
+        JsonObject firstAlias = aliasedFields.get(0).getAsJsonObject();
+        assertEquals("99", firstAlias.get("originalValue").getAsString());
+        assertEquals("EXPECTED_VALUE", firstAlias.get("alias").getAsString());
+    }
+
+    @Test
+    public void shouldIncludeNoteWhenTypesIgnoredConfigured() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanBoolean(false).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanBoolean(true).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .ignoring(String.class)
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        assertTrue(json.has("note"), "Should contain note when type-based ignoring is configured");
+        assertTrue(json.get("note").getAsString().contains("Type-based ignoring"),
+                "Note should mention type-based ignoring");
     }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/ContentMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/ContentMatcherMachineReadableTest.java
@@ -2,6 +2,8 @@ package com.github.karsaig.approvalcrest.matcher.machinereadable;
 
 import com.github.karsaig.approvalcrest.matcher.AbstractFileMatcherTest;
 import com.github.karsaig.approvalcrest.matcher.ContentMatcher;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
@@ -33,15 +35,16 @@ public class ContentMatcherMachineReadableTest extends AbstractFileMatcherTest {
                     () -> assertThat(actual, underTest));
 
             String msg = error.getMessage();
+            JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
             String approvedPath = contentDir.resolve("11b2ef-approved.content").toAbsolutePath().toString();
             assertAll(
-                    () -> assertTrue(msg.contains("FAILURE_TYPE: MISMATCH"), "Should contain failure type header"),
-                    () -> assertTrue(msg.contains("APPROVED_FILE: " + approvedPath), "Should contain approved file path"),
-                    () -> assertTrue(msg.contains("ACTION: Set system property fMUInPlace=true and re-run to update the approved file"), "Should contain update action"),
-                    () -> assertTrue(msg.contains("=== ACTUAL (full) ==="), "Should contain ACTUAL block start"),
-                    () -> assertTrue(msg.contains("=== END ACTUAL ==="), "Should contain ACTUAL block end"),
-                    () -> assertTrue(msg.contains(actual), "Should contain full actual content"),
-                    () -> assertFalse(msg.contains("=== EXPECTED (full) ==="), "Should NOT contain EXPECTED block for file matchers")
+                    () -> assertEquals("MISMATCH", json.get("failureType").getAsString(), "Should contain failureType"),
+                    () -> assertEquals(approvedPath, json.get("approvedFile").getAsString(), "Should contain approved file path"),
+                    () -> assertTrue(json.has("action"), "Should contain action"),
+                    () -> assertTrue(json.has("actual"), "Should contain actual field"),
+                    () -> assertTrue(json.get("actual").getAsString().contains(actual), "Actual should contain the text content"),
+                    () -> assertTrue(json.has("ignoredFields"), "Should contain ignoredFields array"),
+                    () -> assertTrue(json.has("aliasedFields"), "Should contain aliasedFields array")
             );
         });
     }
@@ -62,8 +65,8 @@ public class ContentMatcherMachineReadableTest extends AbstractFileMatcherTest {
 
             String msg = error.getMessage();
             assertAll(
-                    () -> assertFalse(msg.contains("=== ACTUAL (full) ==="), "Should NOT contain machine-readable ACTUAL block"),
-                    () -> assertFalse(msg.contains("APPROVED_FILE:"), "Should NOT contain approved file path label"),
+                    () -> assertFalse(msg.contains("\"failureType\""), "Should NOT contain JSON failureType field"),
+                    () -> assertFalse(msg.contains("\"approvedFile\""), "Should NOT contain JSON approvedFile field"),
                     () -> assertTrue(msg.contains("Content does not match!"), "Should contain diff message")
             );
         });

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
@@ -46,7 +46,8 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
                     () -> assertTrue(json.has("action"), "Should contain action"),
                     () -> assertTrue(json.has("actual"), "Should contain actual field"),
                     () -> assertTrue(json.has("ignoredFields"), "Should contain ignoredFields array"),
-                    () -> assertTrue(json.has("aliasedFields"), "Should contain aliasedFields array")
+                    () -> assertTrue(json.has("aliasedFields"), "Should contain aliasedFields array"),
+                    () -> assertTrue(json.has("sortedFields"), "Should contain sortedFields array")
             );
         });
     }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
@@ -3,6 +3,8 @@ package com.github.karsaig.approvalcrest.matcher.machinereadable;
 import com.github.karsaig.approvalcrest.matcher.AbstractFileMatcherTest;
 import com.github.karsaig.approvalcrest.matcher.JsonMatcher;
 import com.github.karsaig.approvalcrest.testdata.BeanWithPrimitives;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
@@ -35,15 +37,16 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
                     () -> assertThat(actual, underTest));
 
             String msg = error.getMessage();
+            JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
             String approvedPath = jsonDir.resolve("11b2ef-approved.json").toAbsolutePath().toString();
             assertAll(
-                    () -> assertTrue(msg.contains("FAILURE_TYPE: MISMATCH"), "Should contain failure type header"),
-                    () -> assertTrue(msg.contains("TEST: dummyTestClassName#dummyTestMethodName"), "Should contain test info"),
-                    () -> assertTrue(msg.contains("APPROVED_FILE: " + approvedPath), "Should contain approved file path"),
-                    () -> assertTrue(msg.contains("ACTION: Set system property fMUInPlace=true and re-run to update the approved file"), "Should contain update action"),
-                    () -> assertTrue(msg.contains("=== ACTUAL (full) ==="), "Should contain ACTUAL block start"),
-                    () -> assertTrue(msg.contains("=== END ACTUAL ==="), "Should contain ACTUAL block end"),
-                    () -> assertFalse(msg.contains("=== EXPECTED (full) ==="), "Should NOT contain EXPECTED block for file matchers")
+                    () -> assertEquals("MISMATCH", json.get("failureType").getAsString(), "Should contain failureType"),
+                    () -> assertEquals("dummyTestClassName#dummyTestMethodName", json.get("test").getAsString(), "Should contain test info"),
+                    () -> assertEquals(approvedPath, json.get("approvedFile").getAsString(), "Should contain approved file path"),
+                    () -> assertTrue(json.has("action"), "Should contain action"),
+                    () -> assertTrue(json.has("actual"), "Should contain actual field"),
+                    () -> assertTrue(json.has("ignoredFields"), "Should contain ignoredFields array"),
+                    () -> assertTrue(json.has("aliasedFields"), "Should contain aliasedFields array")
             );
         });
     }
@@ -65,10 +68,10 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
                         () -> assertThat(actual, underTest));
 
                 String msg = error.getMessage();
+                JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
                 String approvedPath = jsonDir.resolve("11b2ef-approved.json").toAbsolutePath().toString();
-                assertTrue(msg.contains("APPROVED_FILE: " + approvedPath));
-                assertTrue(msg.contains("=== ACTUAL (full) ==="));
-                assertTrue(msg.contains("=== END ACTUAL ==="));
+                assertEquals(approvedPath, json.get("approvedFile").getAsString());
+                assertTrue(json.has("actual"));
             });
         } finally {
             System.clearProperty("fileMatcherMachineReadable");
@@ -91,8 +94,8 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
 
             String msg = error.getMessage();
             assertAll(
-                    () -> assertFalse(msg.contains("=== ACTUAL (full) ==="), "Should NOT contain machine-readable ACTUAL block"),
-                    () -> assertFalse(msg.contains("APPROVED_FILE:"), "Should NOT contain approved file path label")
+                    () -> assertFalse(msg.contains("\"failureType\""), "Should NOT contain JSON failureType field"),
+                    () -> assertFalse(msg.contains("\"approvedFile\""), "Should NOT contain JSON approvedFile field")
             );
         });
     }
@@ -141,14 +144,12 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
         BeanWithPrimitives actual = getBeanWithPrimitives();
         inMemoryUnixFs(imfsi -> {
             FileSystem fs = imfsi.getInMemoryFileSystem();
-            // 5 levels deep: /projects/myapp/module/src/test/java
             Path deepTestPath;
             try {
                 deepTestPath = Files.createDirectories(fs.getPath("/projects/myapp/module/src/test/java"));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            // Working dir is in a completely separate part of the filesystem
             Path workingDir = fs.getPath("/home/ci/builds/workspace");
 
             DummyInformation dummyTestInfo = new DummyInformation(deepTestPath, imfsi.getResourcePath(), workingDir);
@@ -162,9 +163,11 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
             AssertionFailedError error = assertThrows(AssertionFailedError.class,
                     () -> assertThat(actual, underTest));
 
+            String msg = error.getMessage();
+            JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
             String expectedAbsPath = approvedFile.toAbsolutePath().toString();
-            assertTrue(error.getMessage().contains("APPROVED_FILE: " + expectedAbsPath),
-                    "Absolute path must point to the correct file even when working dir is unrelated. Got: " + error.getMessage());
+            assertEquals(expectedAbsPath, json.get("approvedFile").getAsString(),
+                    "Absolute path must point to the correct file even when working dir is unrelated.");
         });
     }
 
@@ -205,14 +208,12 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
         BeanWithPrimitives actual = getBeanWithPrimitives();
         inMemoryUnixFs(imfsi -> {
             FileSystem fs = imfsi.getInMemoryFileSystem();
-            // 5 levels deep test path: /deep/project/src/test/java/classes
             Path deepTestPath;
             try {
                 deepTestPath = Files.createDirectories(fs.getPath("/deep/project/src/test/java/classes"));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            // Working dir is an ancestor of the approved file's location
             Path workingDir = fs.getPath("/deep/project");
 
             DummyInformation dummyTestInfo = new DummyInformation(deepTestPath, imfsi.getResourcePath(), workingDir);
@@ -226,9 +227,11 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
             AssertionFailedError error = assertThrows(AssertionFailedError.class,
                     () -> assertThat(actual, underTest));
 
+            String msg = error.getMessage();
+            JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
             String expectedAbsPath = approvedFile.toAbsolutePath().toString();
-            assertTrue(error.getMessage().contains("APPROVED_FILE: " + expectedAbsPath),
-                    "Absolute path must be correct even when working dir is an ancestor of the file. Got: " + error.getMessage());
+            assertEquals(expectedAbsPath, json.get("approvedFile").getAsString(),
+                    "Absolute path must be correct even when working dir is an ancestor of the file.");
         });
     }
 
@@ -258,13 +261,67 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
                         () -> assertThat(actual, underTest));
 
                 String msg = error.getMessage();
+                JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
                 String approvedPath = jsonDir.resolve("11b2ef-approved.json").toAbsolutePath().toString();
-                assertTrue(msg.contains("APPROVED_FILE: " + approvedPath));
-                assertTrue(msg.contains("=== ACTUAL (full) ==="));
-                assertTrue(msg.contains("=== END ACTUAL ==="));
+                assertEquals(approvedPath, json.get("approvedFile").getAsString());
+                assertTrue(json.has("actual"));
             });
         } finally {
             System.clearProperty("fMMReadable");
         }
+    }
+
+    @Test
+    public void shouldTrackIgnoredPathsInJsonMatcherOutput() {
+        BeanWithPrimitives actual = getBeanWithPrimitives();
+        inMemoryUnixFs(imfsi -> {
+            DummyInformation dummyTestInfo = dummyInformation(imfsi);
+            JsonMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY.jsonMatcher(dummyTestInfo, getDefaultFileMatcherConfig());
+            underTest.ignoring("beanLong").withMachineReadableOutput();
+
+            Path jsonDir = imfsi.getTestPath().resolve("4ac405");
+            writeApprovedFile(jsonDir, "11b2ef-approved.json", EXISTING_APPROVED_CONTENT);
+
+            AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                    () -> assertThat(actual, underTest));
+
+            String msg = error.getMessage();
+            JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+            com.google.gson.JsonArray ignoredFields = json.getAsJsonArray("ignoredFields");
+            assertTrue(ignoredFields.size() > 0, "ignoredFields should not be empty");
+
+            boolean foundBeanLong = false;
+            for (int i = 0; i < ignoredFields.size(); i++) {
+                JsonObject entry = ignoredFields.get(i).getAsJsonObject();
+                if ("beanLong".equals(entry.get("path").getAsString())
+                        && "IGNORE_PATH".equals(entry.get("reason").getAsString())) {
+                    foundBeanLong = true;
+                    break;
+                }
+            }
+            assertTrue(foundBeanLong, "Should track beanLong as IGNORE_PATH");
+        });
+    }
+
+    @Test
+    public void shouldShowNoteForPatternBasedIgnoringInJsonMatcherOutput() {
+        BeanWithPrimitives actual = getBeanWithPrimitives();
+        inMemoryUnixFs(imfsi -> {
+            DummyInformation dummyTestInfo = dummyInformation(imfsi);
+            JsonMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY.jsonMatcher(dummyTestInfo, getDefaultFileMatcherConfig());
+            underTest.ignoring(org.hamcrest.Matchers.startsWith("beanL")).withMachineReadableOutput();
+
+            Path jsonDir = imfsi.getTestPath().resolve("4ac405");
+            writeApprovedFile(jsonDir, "11b2ef-approved.json", EXISTING_APPROVED_CONTENT);
+
+            AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                    () -> assertThat(actual, underTest));
+
+            String msg = error.getMessage();
+            JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+            assertTrue(json.has("note"), "Should have a note about pattern-based ignoring");
+            String note = json.get("note").getAsString();
+            assertTrue(note.contains("Pattern-based ignoring"), "Note should mention pattern-based ignoring, was: " + note);
+        });
     }
 }

--- a/approvalcrest-junit-jupiter/src/test/java/com/github/karsaig/approvalcrest/MachineReadableDiffViewTest.java
+++ b/approvalcrest-junit-jupiter/src/test/java/com/github/karsaig/approvalcrest/MachineReadableDiffViewTest.java
@@ -35,8 +35,10 @@ public class MachineReadableDiffViewTest {
                 () -> assertTrue(error.isActualDefined(), "Actual must be defined for IDE diff view"),
                 () -> assertNotNull(error.getExpected().getValue(), "Expected value must be non-null"),
                 () -> assertNotNull(error.getActual().getValue(), "Actual value must be non-null"),
-                () -> assertTrue(error.getMessage().contains("=== EXPECTED (full) ==="),
-                        "getMessage() should contain machine-readable expected block"),
+                () -> assertTrue(error.getMessage().contains("\"failureType\""),
+                        "getMessage() should contain JSON failureType field"),
+                () -> assertTrue(error.getMessage().contains("\"expected\""),
+                        "getMessage() should contain JSON expected field"),
                 () -> assertFalse(error.getMessage().contains("expected:<"),
                         "getMessage() should not be polluted by ComparisonCompactor")
         );

--- a/approvalcrest-testng/src/test/java/com/github/karsaig/approvalcrest/testng/MachineReadableDiffViewTest.java
+++ b/approvalcrest-testng/src/test/java/com/github/karsaig/approvalcrest/testng/MachineReadableDiffViewTest.java
@@ -38,8 +38,10 @@ public class MachineReadableDiffViewTest {
         assertTrue(error.isActualDefined(), "Actual must be defined for IDE diff view");
         assertNotNull(error.getExpected().getValue(), "Expected value must be non-null");
         assertNotNull(error.getActual().getValue(), "Actual value must be non-null");
-        assertTrue(error.getMessage().contains("=== EXPECTED (full) ==="),
-                "getMessage() should contain machine-readable expected block");
+        assertTrue(error.getMessage().contains("\"failureType\""),
+                "getMessage() should contain JSON failureType field");
+        assertTrue(error.getMessage().contains("\"expected\""),
+                "getMessage() should contain JSON expected field");
         assertFalse(error.getMessage().contains("expected:<"),
                 "getMessage() should not be polluted by ComparisonCompactor");
     }

--- a/approvalcrest/src/test/java/com/github/karsaig/approvalcrest/MachineReadableDiffViewTest.java
+++ b/approvalcrest/src/test/java/com/github/karsaig/approvalcrest/MachineReadableDiffViewTest.java
@@ -57,8 +57,10 @@ public class MachineReadableDiffViewTest {
 
         assertNotNull("getExpected() must be non-null for IDE diff view", error.getExpected());
         assertNotNull("getActual() must be non-null for IDE diff view", error.getActual());
-        assertTrue("getMessage() should contain machine-readable expected block",
-                error.getMessage().contains("=== EXPECTED (full) ==="));
+        assertTrue("getMessage() should contain JSON failureType field",
+                error.getMessage().contains("\"failureType\""));
+        assertTrue("getMessage() should contain JSON expected field",
+                error.getMessage().contains("\"expected\""));
         assertFalse("getMessage() should not be polluted by ComparisonCompactor",
                 error.getMessage().contains("expected:<"));
     }

--- a/docs/file-control.md
+++ b/docs/file-control.md
@@ -121,48 +121,88 @@ mvn test -DfMMReadable=true
 
 ### Message format
 
-**File matcher — content mismatch:**
-```
-FAILURE_TYPE: MISMATCH
-TEST: MyTest#myTestMethod
-Expected file 4ac405/11b2ef-approved.json
-APPROVED_FILE: /abs/path/to/4ac405/11b2ef-approved.json
-ACTION: Set system property fMUInPlace=true and re-run to update the approved file
+All machine-readable messages are valid JSON objects. The exact fields depend on the failure type.
 
-=== ACTUAL (full) ===
-{ ... current serialized value ... }
-=== END ACTUAL ===
+**File matcher — content mismatch:**
+```json
+{
+  "failureType": "MISMATCH",
+  "test": "MyTest#myTestMethod",
+  "approvedFile": "/abs/path/to/4ac405/11b2ef-approved.json",
+  "action": "Set system property fMUInPlace=true and re-run to update the approved file",
+  "expected": "{ ... approved content ... }",
+  "actual": "{ ... current serialized value ... }",
+  "ignoredFields": [
+    { "path": "createdAt", "reason": "IGNORE_PATH" },
+    { "path": "metadata", "reason": "REMOVED_EMPTY", "causes": ["metadata.id", "metadata.secret"] }
+  ],
+  "aliasedFields": [
+    { "path": "userId", "originalValue": "a1b2c3d4-...", "alias": "%%IGNORED-UUID%%" }
+  ]
+}
 ```
 
 **File matcher — no approved file yet:**
-```
-FAILURE_TYPE: NEW_FILE
-TEST: MyTest#myTestMethod
-Not approved file created: '/abs/path/to/4ac405/11b2ef-not-approved.json';
-APPROVE_TO: /abs/path/to/4ac405/11b2ef-approved.json
-ACTION: Set system property fMUInPlace=true and re-run, or copy the not-approved file to APPROVE_TO path above
+```json
+{
+  "failureType": "NEW_FILE",
+  "test": "MyTest#myTestMethod",
+  "notApprovedFile": "/abs/path/to/4ac405/11b2ef-not-approved.json",
+  "approvedFile": "/abs/path/to/4ac405/11b2ef-approved.json",
+  "action": "Set system property fMUInPlace=true and re-run, or copy the not-approved file to approvedFile path"
+}
 ```
 
 **Bean matcher — value mismatch:**
-```
-FAILURE_TYPE: MISMATCH
-
-=== EXPECTED (full) ===
-{ ... expected ... }
-=== END EXPECTED ===
-
-=== ACTUAL (full) ===
-{ ... actual ... }
-=== END ACTUAL ===
+```json
+{
+  "failureType": "MISMATCH",
+  "expected": "{ ... expected ... }",
+  "actual": "{ ... actual ... }",
+  "ignoredFields": [],
+  "aliasedFields": []
+}
 ```
 
 **Bean matcher — incompatible types:**
+```json
+{
+  "failureType": "TYPE_MISMATCH",
+  "expectedType": "com.example.Foo",
+  "actualType": "com.example.Bar",
+  "action": "Add .skipClassComparison() to the matcher, or set system property bMSCComparison=true"
+}
 ```
-FAILURE_TYPE: TYPE_MISMATCH
-EXPECTED_TYPE: com.example.Foo
-ACTUAL_TYPE: com.example.Bar
-ACTION: Add .skipClassComparison() to the matcher, or set system property bMSCComparison=true
-```
+
+### ignoredFields tracking
+
+The `ignoredFields` array records **which fields were actually removed** during filtering and **why**. Each entry contains:
+
+| Field | Description |
+|-------|-------------|
+| `path` | The dotted path of the removed field (e.g. `address.zipCode`) |
+| `reason` | One of: `IGNORE_PATH`, `CUSTOM_MATCHER`, `CUSTOM_MATCHER_PATTERN`, `IGNORE_PATTERN`, `REMOVED_EMPTY` |
+| `pattern` | *(only for pattern-based)* The matcher description that matched |
+| `causes` | *(only for `REMOVED_EMPTY`)* Child fields whose removal left this parent empty |
+
+**Reason values:**
+- `IGNORE_PATH` — removed by `.ignoring("fieldPath")`
+- `CUSTOM_MATCHER` — removed by `.with("fieldPath", matcher)` (validated separately)
+- `CUSTOM_MATCHER_PATTERN` — removed by `.withMatcher(patternMatcher, valueMatcher)`
+- `IGNORE_PATTERN` — removed by `.ignoring(Matcher<String>)` applied to the JSON tree
+- `REMOVED_EMPTY` — parent became empty after its children were removed
+
+**Note:** Type-based ignoring (`.ignoring(Class)`) and pattern-based ignoring (`.ignoring(Matcher)`) are applied during Gson serialization via an `ExclusionStrategy`, so individual field removals cannot be tracked. When these are configured, a `"note"` field explains this.
+
+### aliasedFields tracking
+
+The `aliasedFields` array records value replacements made by aliasing. Each entry contains:
+
+| Field | Description |
+|-------|-------------|
+| `path` | The dotted path of the aliased field |
+| `originalValue` | The original value before aliasing |
+| `alias` | The replacement value |
 
 ### Passive AI discovery tip
 

--- a/docs/file-control.md
+++ b/docs/file-control.md
@@ -138,6 +138,10 @@ All machine-readable messages are valid JSON objects. The exact fields depend on
   ],
   "aliasedFields": [
     { "path": "userId", "originalValue": "a1b2c3d4-...", "alias": "%%IGNORED-UUID%%" }
+  ],
+  "sortedFields": [
+    { "path": "items", "reason": "SORT_PATH" },
+    { "path": "tags", "reason": "SORT_PATTERN", "pattern": "a string containing \"tag\"" }
   ]
 }
 ```
@@ -160,7 +164,8 @@ All machine-readable messages are valid JSON objects. The exact fields depend on
   "expected": "{ ... expected ... }",
   "actual": "{ ... actual ... }",
   "ignoredFields": [],
-  "aliasedFields": []
+  "aliasedFields": [],
+  "sortedFields": []
 }
 ```
 
@@ -203,6 +208,22 @@ The `aliasedFields` array records value replacements made by aliasing. Each entr
 | `path` | The dotted path of the aliased field |
 | `originalValue` | The original value before aliasing |
 | `alias` | The replacement value |
+
+### sortedFields tracking
+
+The `sortedFields` array records **which array fields were actually sorted** due to user-configured sorting. Each entry contains:
+
+| Field | Description |
+|-------|-------------|
+| `path` | The dotted path of the field whose array was sorted (e.g. `items`, `order.lineItems`) |
+| `reason` | One of: `SORT_PATH`, `SORT_PATTERN` |
+| `pattern` | *(only for `SORT_PATTERN`)* The matcher description that matched |
+
+**Reason values:**
+- `SORT_PATH` — sorted by `.sortField("fieldPath")` or `.sortFieldPath(SortField.of("path"))`
+- `SORT_PATTERN` — sorted by `.sortField(Matcher<String>)` or `.sortFieldMatcher(SortField.of(matcher))`
+
+**Note:** Type-based sorting (`.sortType(Class)`) is applied during Gson serialization (via a field-name marker), so individual field sorts cannot be tracked. When this is configured, the `"note"` field explains this limitation.
 
 ### Passive AI discovery tip
 


### PR DESCRIPTION
## Summary

Migrates the machine-readable output format from line-based key-value to structured JSON, and adds `ignoredFields` and `aliasedFields` tracking that explains why fields are missing from comparison output.

## Changes

### New classes
- `IgnoredFieldsTracker` — accumulates records of removed fields with reason (IGNORE_PATH, CUSTOM_MATCHER, IGNORE_PATTERN, CUSTOM_MATCHER_PATTERN, REMOVED_EMPTY)
- `AliasTracker` — accumulates records of aliased values (path, originalValue, alias)

### Core changes
- `ComparisonDescription.buildMachineReadableMessage()` — rewritten to emit JSON via Gson JsonObject
- `FieldsIgnorer.findPaths()` — added tracked overload with IgnoredFieldsTracker + reason map
- `JsonElementUtil` — added tracked overloads for `filterByFieldMatchers()`, `filterByCustomMatcherPatterns()`, `applyAliases()`

### Matcher integration
- `DiagnosingCustomisableMatcher` — creates trackers, passes through filter chain, includes note for type/pattern-based ignoring
- `JsonMatcher` — same tracker integration, with note for type/pattern-based ignoring (both applied during Gson serialization via ExclusionStrategy)
- `AbstractDiagnosingFileMatcher` — NEW_FILE message now emits JSON; sets approvedFile/testInfo on ComparisonDescription

### Tests
- All existing machine-readable tests updated for new JSON format
- New tests: ignored path tracking, empty arrays, custom matcher tracking, alias tracking, untracked note for types/patterns
- All tests pass on JDK 8, 11, 17, 21, 25

## Public API
No changes to the public API. New tracker classes are public (required for cross-package access) but are internal infrastructure.