### PR TITLE
Add fmAI alias for machine-readable output and update AI tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 ===========
 
+Version 1.3.0 - 2026/06/01
+-----
+
+- Machine-readable output is now structured JSON. Failure messages emitted with `-DfileMatcherMachineReadable=true` (or `withMachineReadableOutput()`) are valid JSON objects containing `failureType`, `test`, `approvedFile`/`approveTo`, `expected`, `actual`, plus metadata arrays `ignoredFields`, `aliasedFields`, and `sortedFields` that document what transformations were applied. See [file-control](docs/file-control.md).
+- Added `fmAI` as an additional short alias for the machine-readable output system property (`-DfmAI=true`). The passive AI discovery tip appended to non-machine-readable failures now references `fmAI` for brevity. The original alias `fMMReadable` remains valid. See [system-properties](docs/system-properties.md).
+- Added JDK 17+ integration tests for records and sealed classes (`approvalcrest-jdk17-integration-tests` module).
+- Fixed generic type serialization bug with Immutables `@Gson.TypeAdapters`: types registered via `GsonBuilder.registerTypeAdapterFactory` no longer cause `IllegalStateException` during recursive adapter resolution.
+- `LenientTypeAdapterFactory` now logs the full exception (including stack trace) when catching `IllegalStateException`, and deduplicates repeated warnings for the same type to reduce log noise.
+
 Version 1.2.0 - 2026/05/30
 -----
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ When a test fails, enable machine-readable output so that AI agents and CI tooli
 assertThat(actual, sameJsonAsApproved().withMachineReadableOutput());
 ```
 ```
-# Or via system property:
+# Or via system property (short alias fmAI also works):
 mvn test -DfileMatcherMachineReadable=true
 ```
 

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
@@ -116,7 +116,7 @@ public class ComparisonDescription extends StringDescription {
 			return buildMachineReadableMessage(reason);
 		}
 		return (isNotBlank(reason) ? reason + "\n" : "") + getDifferencesMessage()
-				+ "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+				+ "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
 	}
 
 	private String buildMachineReadableMessage(String reason) {

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/AbstractDiagnosingMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/AbstractDiagnosingMatcher.java
@@ -39,9 +39,10 @@ public abstract class AbstractDiagnosingMatcher<T> extends DiagnosingMatcher<T> 
             Pattern.compile("module (\\S+) does not \"opens (\\S+)\"");
 
     private static final String MACHINE_READABLE_ALIAS = "fMMReadable";
+    private static final String MACHINE_READABLE_AI_ALIAS = "fmAI";
 
     private boolean comparisonDescriptionNeeded = false;
-    protected boolean machineReadableOutput = getBooleanProperties(null, "fileMatcherMachineReadable", MACHINE_READABLE_ALIAS);
+    protected boolean machineReadableOutput = getBooleanProperties(null, "fileMatcherMachineReadable", MACHINE_READABLE_ALIAS, MACHINE_READABLE_AI_ALIAS);
 
     /**
      * Template-method entry point. Subclasses implement their matching logic here.

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractTest.java
@@ -11,7 +11,7 @@ import java.util.function.BiConsumer;
 public abstract class AbstractTest {
 
     protected static final TestAssertImpl TEST_ASSERT_IMPl = new TestAssertImpl();
-    protected static final String AI_TIP_SUFFIX = "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+    protected static final String AI_TIP_SUFFIX = "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
 
     protected static String removeAiTip(String message) {
         if (message != null && message.endsWith(AI_TIP_SUFFIX)) {

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
@@ -272,6 +272,33 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
         }
     }
 
+    // Alias test — fmAI alias should enable machine-readable output
+    @Test
+    public void shouldOutputMachineReadableMessageWhenFmAIAliasPropertyEnabled() {
+        BeanWithPrimitives actual = getBeanWithPrimitives();
+        System.setProperty("fmAI", "true");
+        try {
+            inMemoryUnixFs(imfsi -> {
+                DummyInformation dummyTestInfo = dummyInformation(imfsi);
+                JsonMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY.jsonMatcher(dummyTestInfo, getDefaultFileMatcherConfig());
+
+                Path jsonDir = imfsi.getTestPath().resolve("4ac405");
+                writeApprovedFile(jsonDir, "11b2ef-approved.json", EXISTING_APPROVED_CONTENT);
+
+                AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                        () -> assertThat(actual, underTest));
+
+                String msg = error.getMessage();
+                JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+                String approvedPath = jsonDir.resolve("11b2ef-approved.json").toAbsolutePath().toString();
+                assertEquals(approvedPath, json.get("approvedFile").getAsString());
+                assertTrue(json.has("actual"));
+            });
+        } finally {
+            System.clearProperty("fmAI");
+        }
+    }
+
     @Test
     public void shouldTrackIgnoredPathsInJsonMatcherOutput() {
         BeanWithPrimitives actual = getBeanWithPrimitives();

--- a/approvalcrest-integration-tests/src/test/java/samebean/SameBeanTest.java
+++ b/approvalcrest-integration-tests/src/test/java/samebean/SameBeanTest.java
@@ -44,7 +44,7 @@ public class SameBeanTest {
                 "Unexpected: beanLong\n" +
                 " ; \n" +
                 "Unexpected: beanShort\n" +
-                "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+                "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
         String expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
+++ b/approvalcrest-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
@@ -3,7 +3,7 @@
   "0x1": {
     "fExpected": "Different content",
     "fActual": "Lorem ipsum dolor sit amet, inani nullam oportere no cum.",
-    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "suppressedExceptions": [],
     "class": "org.junit.ComparisonFailure"
   }

--- a/approvalcrest-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
+++ b/approvalcrest-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
@@ -2,7 +2,7 @@
 {
   "0x1": {
     "class": "org.junit.ComparisonFailure",
-    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "fActual": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}",
     "fExpected": "{\n  \"different\": \"content\"\n}",
     "suppressedExceptions": []

--- a/approvalcrest-junit-jupiter-integration-tests-junit6/src/test/java/samebean/SameBeanTest.java
+++ b/approvalcrest-junit-jupiter-integration-tests-junit6/src/test/java/samebean/SameBeanTest.java
@@ -44,7 +44,7 @@ public class SameBeanTest {
                 "Unexpected: beanLong\n" +
                 " ; \n" +
                 "Unexpected: beanShort\n" +
-                "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+                "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
         String expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-junit-jupiter-integration-tests-junit6/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-jupiter-integration-tests-junit6/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "Lorem ipsum dolor sit amet, inani nullam oportere no cum."
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "Different content\n",
       "type": "java.lang.String",

--- a/approvalcrest-junit-jupiter-integration-tests-junit6/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-jupiter-integration-tests-junit6/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}"
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "{\n  \"different\": \"content\"\n}",
       "type": "java.lang.String",

--- a/approvalcrest-junit-jupiter-integration-tests/src/test/java/samebean/SameBeanTest.java
+++ b/approvalcrest-junit-jupiter-integration-tests/src/test/java/samebean/SameBeanTest.java
@@ -44,7 +44,7 @@ public class SameBeanTest {
                 "Unexpected: beanLong\n" +
                 " ; \n" +
                 "Unexpected: beanShort\n" +
-                "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+                "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
         String expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-junit-jupiter-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-jupiter-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "Lorem ipsum dolor sit amet, inani nullam oportere no cum."
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "Different content",
       "type": "java.lang.String",

--- a/approvalcrest-junit-jupiter-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-jupiter-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}"
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "{\n  \"different\": \"content\"\n}",
       "type": "java.lang.String",

--- a/approvalcrest-junit-jupiter-kotlin-integration-tests/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/4e5799/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-jupiter-kotlin-integration-tests/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/4e5799/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "Lorem ipsum dolor sit amet, inani nullam oportere no cum."
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file 4e5799/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file 4e5799/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "Different content",
       "type": "java.lang.String",

--- a/approvalcrest-junit-jupiter-kotlin-integration-tests/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/6eeaa9/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-jupiter-kotlin-integration-tests/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/6eeaa9/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}"
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file 6eeaa9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file 6eeaa9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "{\n  \"different\": \"content\"\n}",
       "type": "java.lang.String",

--- a/approvalcrest-junit-jupiter-kotlin-integration-tests/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/KotlinSameBeanTest.kt
+++ b/approvalcrest-junit-jupiter-kotlin-integration-tests/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/KotlinSameBeanTest.kt
@@ -39,7 +39,7 @@ class KotlinSameBeanTest {
                 "Unexpected: beanLong\n" +
                 " ; \n" +
                 "Unexpected: beanShort\n" +
-                "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output."
+                "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output."
         val expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-junit-vintage-integration-tests/src/test/java/jupiter/6c1826/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-vintage-integration-tests/src/test/java/jupiter/6c1826/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}"
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file 6c1826/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file 6c1826/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "{\n  \"different\": \"content\"\n}",
       "type": "java.lang.String",

--- a/approvalcrest-junit-vintage-integration-tests/src/test/java/jupiter/SameBeanTest.java
+++ b/approvalcrest-junit-vintage-integration-tests/src/test/java/jupiter/SameBeanTest.java
@@ -45,7 +45,7 @@ public class SameBeanTest {
                 "Unexpected: beanLong\n" +
                 " ; \n" +
                 "Unexpected: beanShort\n" +
-                "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+                "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
         String expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-junit-vintage-integration-tests/src/test/java/jupiter/ce1be7/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-vintage-integration-tests/src/test/java/jupiter/ce1be7/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "Lorem ipsum dolor sit amet, inani nullam oportere no cum."
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file ce1be7/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file ce1be7/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "Different content",
       "type": "java.lang.String",

--- a/approvalcrest-junit-vintage-integration-tests/src/test/java/samebean/SameBeanTest.java
+++ b/approvalcrest-junit-vintage-integration-tests/src/test/java/samebean/SameBeanTest.java
@@ -28,7 +28,7 @@ public class SameBeanTest {
         BeanWithPrimitives actual = getBeanWithPrimitivesMinValues();
 
         Optional<BeanWithPrimitives> expected = Optional.empty();
-        String expectedMessage = "\nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+        String expectedMessage = "\nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
         String expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-junit-vintage-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-vintage-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
@@ -2,7 +2,7 @@
 {
   "0x1": {
     "class": "org.junit.ComparisonFailure",
-    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "fActual": "Lorem ipsum dolor sit amet, inani nullam oportere no cum.",
     "fExpected": "Different content",
     "suppressedExceptions": []

--- a/approvalcrest-junit-vintage-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
+++ b/approvalcrest-junit-vintage-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
@@ -2,7 +2,7 @@
 {
   "0x1": {
     "class": "org.junit.ComparisonFailure",
-    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.",
+    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.",
     "fActual": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}",
     "fExpected": "{\n  \"different\": \"content\"\n}",
     "suppressedExceptions": []

--- a/approvalcrest-testng-integration-tests-testng6/src/test/java/samebean/SameBeanTest.java
+++ b/approvalcrest-testng-integration-tests-testng6/src/test/java/samebean/SameBeanTest.java
@@ -44,7 +44,7 @@ public class SameBeanTest {
                 "Unexpected: beanLong\n" +
                 " ; \n" +
                 "Unexpected: beanShort\n" +
-                "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+                "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
         String expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-testng-integration-tests-testng6/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
+++ b/approvalcrest-testng-integration-tests-testng6/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "Lorem ipsum dolor sit amet, inani nullam oportere no cum."
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable\u003dtrue for structured, machine-readable output.",
+    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI\u003dtrue for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "This is different content that should cause a mismatch.\n",
       "type": "java.lang.String",

--- a/approvalcrest-testng-integration-tests-testng6/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
+++ b/approvalcrest-testng-integration-tests-testng6/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}"
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable\u003dtrue for structured, machine-readable output.",
+    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI\u003dtrue for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "{\n  \"different\": \"content\"\n}",
       "type": "java.lang.String",

--- a/approvalcrest-testng-integration-tests/src/test/java/samebean/SameBeanTest.java
+++ b/approvalcrest-testng-integration-tests/src/test/java/samebean/SameBeanTest.java
@@ -44,7 +44,7 @@ public class SameBeanTest {
                 "Unexpected: beanLong\n" +
                 " ; \n" +
                 "Unexpected: beanShort\n" +
-                "\n[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.";
+                "\n[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.";
         String expectedActualValue = "{\n" +
                 "  \"beanBoolean\": false,\n" +
                 "  \"beanByte\": -128,\n" +

--- a/approvalcrest-testng-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
+++ b/approvalcrest-testng-integration-tests/src/test/java/samecontent/f89d26/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "Lorem ipsum dolor sit amet, inani nullam oportere no cum."
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fMMReadable\u003dtrue for structured, machine-readable output.",
+    "detailMessage": "Expected file f89d26/fd51ac-approved.content\nContent does not match!\n[AI tip] Re-run with system property fmAI\u003dtrue for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "This is different content that should cause a mismatch.\n",
       "type": "java.lang.String",

--- a/approvalcrest-testng-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
+++ b/approvalcrest-testng-integration-tests/src/test/java/samejson/f4eff9/fd51ac-thrown-approved.json
@@ -7,7 +7,7 @@
       "value": "{\n  \"beanBoolean\": false,\n  \"beanByte\": 127,\n  \"beanChar\": \"￿\",\n  \"beanDouble\": 1.7976931348623157E308,\n  \"beanFloat\": 3.4028235E38,\n  \"beanInteger\": 2147483647,\n  \"beanLong\": 9223372036854775807,\n  \"beanShort\": 32767\n}"
     },
     "class": "org.opentest4j.AssertionFailedError",
-    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fMMReadable\u003dtrue for structured, machine-readable output.",
+    "detailMessage": "Expected file f4eff9/fd51ac-approved.json\n\nExpected: different\n     but none found\n ; \nUnexpected: beanBoolean\n ; \nUnexpected: beanByte\n ; \nUnexpected: beanChar\n ; \nUnexpected: beanDouble\n ; \nUnexpected: beanFloat\n ; \nUnexpected: beanInteger\n ; \nUnexpected: beanLong\n ; \nUnexpected: beanShort\n\n[AI tip] Re-run with system property fmAI\u003dtrue for structured, machine-readable output.",
     "expected": {
       "stringRepresentation": "{\n  \"different\": \"content\"\n}",
       "type": "java.lang.String",

--- a/docs/file-control.md
+++ b/docs/file-control.md
@@ -115,7 +115,8 @@ assertThat(actual, sameJsonAsApproved().withMachineReadableOutput());
 
 ```bash
 mvn test -DfileMatcherMachineReadable=true
-# or using the alias:
+# or using the short aliases:
+mvn test -DfmAI=true
 mvn test -DfMMReadable=true
 ```
 
@@ -230,7 +231,7 @@ The `sortedFields` array records **which array fields were actually sorted** due
 In the default (non-machine-readable) mode, every failure message ends with:
 
 ```
-[AI tip] Re-run with system property fMMReadable=true for structured, machine-readable output.
+[AI tip] Re-run with system property fmAI=true for structured, machine-readable output.
 ```
 
 This allows AI agents that encounter a normal test failure to discover the machine-readable mode without any explicit configuration.

--- a/docs/system-properties.md
+++ b/docs/system-properties.md
@@ -21,7 +21,7 @@ Setting them to **different values** throws `IllegalStateException` at test star
 | `useApprovedDirectory` | `uADirectory` | `false` | Store approved files in a dedicated `approved/` directory tree instead of alongside test sources. | [file-control](file-control.md) |
 | `sortInputFile` | `sIFile` | `false` | Sort the input before writing it to the approved file. | [sorting](sorting.md) |
 | `fileMatcherStrictFileMatching` | `fMStrictMatching` | `true` | Ignore stripping applies to the actual side only; approved files must not contain the ignored field's value. Disable to restore two-sided ignore behaviour. | [ignoring-fields](ignoring-fields.md) |
-| `fileMatcherMachineReadable` | `fMMReadable` | `false` | Replace human-readable failure messages with structured, machine-actionable output for AI agents and CI pipelines. | [file-control](file-control.md) |
+| `fileMatcherMachineReadable` | `fMMReadable`, `fmAI` | `false` | Replace human-readable failure messages with structured, machine-actionable output for AI agents and CI pipelines. | [file-control](file-control.md) |
 | `beanMatcherSkipClassComparison` | `bMSCComparison` | `false` | Skip the runtime-type check in `sameBeanAs`; allows comparing objects of different but structurally compatible classes. | [same-bean-as](same-bean-as.md) |
 | `approvalcrestSerializeNulls` | `aSerNulls` | `true` | Include null-valued fields in Gson serialization. Disabling reverts to the pre-1.0.2 behaviour where null fields were silently omitted. | [ignoring-fields](ignoring-fields.md) |
 
@@ -35,5 +35,5 @@ mvn test -DfMUInPlace=true
 mvn test -DaSerNulls=false
 
 # Enable machine-readable output for AI agents
-mvn test -DfMMReadable=true
+mvn test -DfmAI=true
 ```


### PR DESCRIPTION
- Add 'fmAI' as additional short alias for fileMatcherMachineReadable
- Update passive AI discovery tip to reference fmAI=true
- Add alias test in JsonMatcherMachineReadableTest
- Update integration tests and approved JSON files
- Update documentation (system-properties, file-control, README)
- Add CHANGELOG entry for version 1.3.0