### PR TITLE
Add migration guide for path handling and IDE run template best practice

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -147,6 +147,33 @@ Keep approved files alongside the test source files in the same package director
 
 See [file-control](file-control.md) for options to customise file naming and paths when needed for specific scenarios.
 
+## IDE Run Templates
+
+Add `fileMatcherPassOnCreate` and `fileMatcherUpdateInPlace` to your IDE's JUnit run template with value `false`. This makes the properties **visible and easy to toggle** — when you need to create or update approved files, just flip `false` to `true` in the run configuration without having to remember the property names.
+
+**IntelliJ IDEA:**
+
+1. Open **Run → Edit Configurations → Edit Configuration Templates → JUnit**
+2. In the **VM options** field, add:
+
+```
+-DfMPOnCreate=false -DfMUInPlace=false
+```
+
+Or using the full property names:
+
+```
+-DfileMatcherPassOnCreate=false -DfileMatcherUpdateInPlace=false
+```
+
+When you need to create or update approved files, change the values to `true` in the run configuration:
+- **`fileMatcherPassOnCreate` / `fMPOnCreate`** — set to `true` to pass the test when no approved file exists yet (instead of failing with "Not approved file created"). The not-approved file is still written so you can review it.
+- **`fileMatcherUpdateInPlace` / `fMUInPlace`** — set to `true` to overwrite existing approved files with the current actual output.
+
+This enables fast iteration: flip the flag to `true`, run the test, inspect the generated approved file, flip back to `false`, and commit. No need to remember property names or type them from scratch.
+
+**Tip:** review `git diff` before committing to verify that overwritten approved files contain the expected changes. Always flip back to `false` after updating — running with `true` permanently masks real test failures.
+
 ## Multiple Assertions in One Test
 
 Each file-based matcher call derives its filename from the test class and method name. If a test makes more than one assertion with `sameJsonAsApproved()` or `sameContentAsApproved()`, all calls would resolve to the same filename and collide. Use `.withUniqueId(String id)` on every call to give each one a distinct filename:

--- a/docs/file-control.md
+++ b/docs/file-control.md
@@ -89,6 +89,41 @@ assertThat(actual, sameJsonAsApproved()
 
 **Migration from pre-1.0.1:** previously `withRelativePathName("snapshots")` wrote to `{testClassPath}/snapshots/`. Move existing approved files to `{workingDir}/snapshots/<classHash>/`.
 
+## Migration from pre-1.0.0 Without Moving Files
+
+In pre-1.0.0, `withPathName(str)` resolved relative to the **working directory**. Since 1.0.0, it resolves relative to **testClassPath**. If your tests used `withPathName` with a path from the project root, the approved files would now be looked up under the wrong directory.
+
+To keep approved files in place **without moving them**, split the old `withPathName` call into `withRelativePathName` (base from working directory) + `withPathName` (subdirectory):
+
+**Before (pre-1.0.0):**
+
+```java
+// Resolved from working directory → src/test/jsons/<file>
+assertThat(actual, sameJsonAsApproved()
+    .withPathName("src/test/jsons")
+    .withFileName("my-snapshot"));
+```
+
+**After (1.0.0+):**
+
+```java
+// withRelativePathName resolves from workingDir, withPathName adds subdirectory
+assertThat(actual, sameJsonAsApproved()
+    .withRelativePathName("src/test")
+    .withPathName("jsons")
+    .withFileName("my-snapshot"));
+```
+
+Both produce the same absolute path: `{projectRoot}/src/test/jsons/my-snapshot-approved.json`. The approved file stays in place — no rename or move needed.
+
+**Resolution logic when both are set:**
+
+```
+fileNameWithPath = workingDirectory() / relativePathName / pathName / fileName
+```
+
+Since `workingDirectory()` is the project root, this is equivalent to the old `withPathName` behaviour that resolved directly from the working directory.
+
 ## In-Place Update
 
 Re-running tests with `-DfileMatcherUpdateInPlace=true` overwrites approved files with the current actual output:


### PR DESCRIPTION
- docs/file-control.md: Add 'Migration from pre-1.0.0 Without Moving Files' section explaining how to split withPathName into withRelativePathName + withPathName to keep approved files in place after the 1.0.0 path resolution change.

- docs/best-practices.md: Add 'IDE Run Templates' section documenting how to configure IntelliJ IDEA JUnit templates with fMPOnCreate and fMUInPlace VM options for fast local iteration.