### PR TITLE
Compact expected/actual JSON in machine-readable output

### DIFF
--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
@@ -20,6 +20,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonParseException;
 import org.hamcrest.StringDescription;
 
 /**
@@ -27,6 +29,7 @@ import org.hamcrest.StringDescription;
  */
 public class ComparisonDescription extends StringDescription {
 	private static final Gson OUTPUT_GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+	private static final Gson COMPACT_GSON = new GsonBuilder().disableHtmlEscaping().create();
 
 	private String actual;
 	private String expected;
@@ -130,10 +133,10 @@ public class ComparisonDescription extends StringDescription {
 			root.addProperty("action", "Set system property fMUInPlace=true and re-run to update the approved file");
 		}
 		if (expected != null) {
-			root.addProperty("expected", expected);
+			root.addProperty("expected", compactJson(expected));
 		}
 		if (actual != null) {
-			root.addProperty("actual", actual);
+			root.addProperty("actual", compactJson(actual));
 		}
 		root.add("ignoredFields", buildIgnoredFieldsArray());
 		root.add("aliasedFields", buildAliasedFieldsArray());
@@ -195,5 +198,13 @@ public class ComparisonDescription extends StringDescription {
 			}
 		}
 		return arr;
+	}
+
+	private String compactJson(String json) {
+		try {
+			return COMPACT_GSON.toJson(JsonParser.parseString(json));
+		} catch (JsonParseException e) {
+			return json;
+		}
 	}
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/BeanMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/BeanMatcherMachineReadableTest.java
@@ -273,4 +273,24 @@ public class BeanMatcherMachineReadableTest extends AbstractTest {
         assertTrue(json.get("note").getAsString().contains("Type-based sorting"),
                 "Note should mention type-based sorting");
     }
+
+    @Test
+    public void shouldOutputCompactExpectedAndActualInMachineReadableJson() {
+        BeanWithPrimitives expected = beanWithPrimitives().beanBoolean(false).beanInt(99).build();
+        BeanWithPrimitives actual = beanWithPrimitives().beanBoolean(true).beanInt(42).build();
+
+        DiagnosingCustomisableMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY
+                .beanMatcher(expected)
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        String msg = error.getMessage();
+        JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+        String expectedValue = json.get("expected").getAsString();
+        String actualValue = json.get("actual").getAsString();
+        assertFalse(expectedValue.contains("\n"), "expected JSON value in machine-readable output must be compact (no newlines)");
+        assertFalse(actualValue.contains("\n"), "actual JSON value in machine-readable output must be compact (no newlines)");
+    }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/machinereadable/JsonMatcherMachineReadableTest.java
@@ -352,4 +352,27 @@ public class JsonMatcherMachineReadableTest extends AbstractFileMatcherTest {
             assertTrue(note.contains("Pattern-based ignoring"), "Note should mention pattern-based ignoring, was: " + note);
         });
     }
+
+    @Test
+    public void shouldOutputCompactExpectedAndActualInMachineReadableJson() {
+        BeanWithPrimitives actual = getBeanWithPrimitives();
+        inMemoryUnixFs(imfsi -> {
+            DummyInformation dummyTestInfo = dummyInformation(imfsi);
+            JsonMatcher<BeanWithPrimitives> underTest = MATCHER_FACTORY.jsonMatcher(dummyTestInfo, getDefaultFileMatcherConfig());
+            underTest.withMachineReadableOutput();
+
+            Path jsonDir = imfsi.getTestPath().resolve("4ac405");
+            writeApprovedFile(jsonDir, "11b2ef-approved.json", EXISTING_APPROVED_CONTENT);
+
+            AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                    () -> assertThat(actual, underTest));
+
+            String msg = error.getMessage();
+            JsonObject json = JsonParser.parseString(msg).getAsJsonObject();
+            String expectedValue = json.get("expected").getAsString();
+            String actualValue = json.get("actual").getAsString();
+            assertFalse(expectedValue.contains("\n"), "expected JSON value in machine-readable output must be compact (no newlines)");
+            assertFalse(actualValue.contains("\n"), "actual JSON value in machine-readable output must be compact (no newlines)");
+        });
+    }
 }


### PR DESCRIPTION
When machine-readable output is enabled, the expected and actual JSON values embedded as string properties in the failure JSON were pretty-printed (from GsonProvider's setPrettyPrinting()), adding unnecessary escaped newlines and spaces that waste AI token budget.

Add COMPACT_GSON and a compactJson() helper in ComparisonDescription. Apply compactJson() to the expected and actual values only inside buildMachineReadableMessage(), so the IDE diff view (which uses the stored fields directly) is unaffected.

Add tests to BeanMatcherMachineReadableTest and
JsonMatcherMachineReadableTest asserting that the expected and actual string values in the machine-readable JSON contain no newline characters.