### PR TITLE
Compact outer machine-readable JSON output across all failure types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Version 1.3.2 - 2026/06/02
 -----
 
+- Machine-readable JSON output is now emitted in compact form (no pretty-printing) to minimise token usage for AI consumers. The `expected` and `actual` field values, as well as the outer JSON wrapper, are all serialised without whitespace across all failure types (`MISMATCH`, `NEW_FILE`, `TYPE_MISMATCH`).
 - Fixed path-based operations (`.ignoring("path")`, `.with("path", matcher)`, `.sortField("path")`, `SortField.ignoring("path")`) failing when the path traverses through a type detected as having a circular reference. `GraphAdapterBuilder` wraps such types with synthetic `0xN` envelope keys, which broke path resolution. These envelope keys are now transparently skipped during path navigation — the user-specified path works identically whether the target type has circular references or not.
 
 Version 1.3.1 - 2026/06/01

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ComparisonDescription.java
@@ -28,8 +28,7 @@ import org.hamcrest.StringDescription;
  * {@link StringDescription} which holds the mismatch message along with the actual and expected Json representation.
  */
 public class ComparisonDescription extends StringDescription {
-	private static final Gson OUTPUT_GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-	private static final Gson COMPACT_GSON = new GsonBuilder().disableHtmlEscaping().create();
+	private static final Gson OUTPUT_GSON = new GsonBuilder().disableHtmlEscaping().create();
 
 	private String actual;
 	private String expected;
@@ -202,7 +201,7 @@ public class ComparisonDescription extends StringDescription {
 
 	private String compactJson(String json) {
 		try {
-			return COMPACT_GSON.toJson(JsonParser.parseString(json));
+			return OUTPUT_GSON.toJson(JsonParser.parseString(json));
 		} catch (JsonParseException e) {
 			return json;
 		}

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -78,7 +78,7 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
                     root.addProperty("expectedType", expected.getClass().getName());
                     root.addProperty("actualType", actual.getClass().getName());
                     root.addProperty("action", "Add .skipClassComparison() to the matcher, or set system property bMSCComparison=true");
-                    Gson outputGson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+                    Gson outputGson = new GsonBuilder().disableHtmlEscaping().create();
                     mismatchDescription.appendText(outputGson.toJson(root));
                 } else {
                     mismatchDescription.appendText("Actual type ["+actual.getClass()+"] is not an instance of expected type ["+expected.getClass()+"]!\nThis can be ignored with skipClassComparison or\nsetting beanMatcherSkipClassComparison env variable to true");

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/file/AbstractDiagnosingFileMatcher.java
@@ -34,7 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public abstract class AbstractDiagnosingFileMatcher<T, U extends AbstractDiagnosingFileMatcher<T, U>> extends AbstractDiagnosingMatcher<T> implements ApprovedFileMatcher<U> {
 
-    private static final Gson JSON_OUTPUT_GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+    private static final Gson JSON_OUTPUT_GSON = new GsonBuilder().disableHtmlEscaping().create();
     public static final int NUM_OF_HASH_CHARS = 6;
     protected final FileStoreMatcherUtils fileStoreMatcherUtils;
     protected final FileMatcherConfig fileMatcherConfig;

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractFileMatcherTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractFileMatcherTest.java
@@ -292,7 +292,7 @@ public abstract class AbstractFileMatcherTest extends AbstractTest {
         json.addProperty("notApprovedFile", notApprovedAbsolutePath.toAbsolutePath().toString());
         json.addProperty("approveTo", approvedAbsolutePath.toAbsolutePath().toString());
         json.addProperty("action", "Set system property fMUInPlace=true and re-run, or copy the not-approved file to approveTo path above");
-        return new com.google.gson.GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(json);
+        return new com.google.gson.GsonBuilder().disableHtmlEscaping().create().toJson(json);
     }
 
     protected void writeFile(Path path, String content) {

--- a/docs/file-control.md
+++ b/docs/file-control.md
@@ -157,62 +157,26 @@ mvn test -DfMMReadable=true
 
 ### Message format
 
-All machine-readable messages are valid JSON objects. The exact fields depend on the failure type.
+All machine-readable messages are valid JSON objects emitted in compact form (no whitespace) to minimise token usage for AI consumers. The exact fields depend on the failure type.
 
 **File matcher — content mismatch:**
-```json
-{
-  "failureType": "MISMATCH",
-  "test": "MyTest#myTestMethod",
-  "approvedFile": "/abs/path/to/4ac405/11b2ef-approved.json",
-  "action": "Set system property fMUInPlace=true and re-run to update the approved file",
-  "expected": "{ ... approved content ... }",
-  "actual": "{ ... current serialized value ... }",
-  "ignoredFields": [
-    { "path": "createdAt", "reason": "IGNORE_PATH" },
-    { "path": "metadata", "reason": "REMOVED_EMPTY", "causes": ["metadata.id", "metadata.secret"] }
-  ],
-  "aliasedFields": [
-    { "path": "userId", "originalValue": "a1b2c3d4-...", "alias": "%%IGNORED-UUID%%" }
-  ],
-  "sortedFields": [
-    { "path": "items", "reason": "SORT_PATH" },
-    { "path": "tags", "reason": "SORT_PATTERN", "pattern": "a string containing \"tag\"" }
-  ]
-}
+```
+{"failureType":"MISMATCH","test":"MyTest#myTestMethod","approvedFile":"/abs/path/to/4ac405/11b2ef-approved.json","action":"Set system property fMUInPlace=true and re-run to update the approved file","expected":"{...approved content...}","actual":"{...current serialized value...}","ignoredFields":[{"path":"createdAt","reason":"IGNORE_PATH"},{"path":"metadata","reason":"REMOVED_EMPTY","causes":["metadata.id","metadata.secret"]}],"aliasedFields":[{"path":"userId","originalValue":"a1b2c3d4-...","alias":"%%IGNORED-UUID%%"}],"sortedFields":[{"path":"items","reason":"SORT_PATH"},{"path":"tags","reason":"SORT_PATTERN","pattern":"a string containing \"tag\""}]}
 ```
 
 **File matcher — no approved file yet:**
-```json
-{
-  "failureType": "NEW_FILE",
-  "test": "MyTest#myTestMethod",
-  "notApprovedFile": "/abs/path/to/4ac405/11b2ef-not-approved.json",
-  "approvedFile": "/abs/path/to/4ac405/11b2ef-approved.json",
-  "action": "Set system property fMUInPlace=true and re-run, or copy the not-approved file to approvedFile path"
-}
+```
+{"failureType":"NEW_FILE","test":"MyTest#myTestMethod","notApprovedFile":"/abs/path/to/4ac405/11b2ef-not-approved.json","approvedFile":"/abs/path/to/4ac405/11b2ef-approved.json","action":"Set system property fMUInPlace=true and re-run, or copy the not-approved file to approvedFile path"}
 ```
 
 **Bean matcher — value mismatch:**
-```json
-{
-  "failureType": "MISMATCH",
-  "expected": "{ ... expected ... }",
-  "actual": "{ ... actual ... }",
-  "ignoredFields": [],
-  "aliasedFields": [],
-  "sortedFields": []
-}
+```
+{"failureType":"MISMATCH","expected":"{...expected...}","actual":"{...actual...}","ignoredFields":[],"aliasedFields":[],"sortedFields":[]}
 ```
 
 **Bean matcher — incompatible types:**
-```json
-{
-  "failureType": "TYPE_MISMATCH",
-  "expectedType": "com.example.Foo",
-  "actualType": "com.example.Bar",
-  "action": "Add .skipClassComparison() to the matcher, or set system property bMSCComparison=true"
-}
+```
+{"failureType":"TYPE_MISMATCH","expectedType":"com.example.Foo","actualType":"com.example.Bar","action":"Add .skipClassComparison() to the matcher, or set system property bMSCComparison=true"}
 ```
 
 ### ignoredFields tracking


### PR DESCRIPTION
Remove setPrettyPrinting() from OUTPUT_GSON (MISMATCH wrapper), JSON_OUTPUT_GSON (NEW_FILE), and the inline outputGson (TYPE_MISMATCH). The outer JSON envelope is now emitted without whitespace, matching the already-compact expected/actual values from the previous commit.

Update AbstractFileMatcherTest helper and docs/file-control.md to reflect compact format. Add CHANGELOG entry for 1.3.2.