### PR TITLE
Add ignoringElementsWhere to remove array elements by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Changelog
 ===========
 
+Version 1.4.1 - 2026/07/12
+-----
+
+- Added `ignoringElementsWhere` to remove array elements from the comparison based on the value of a nested field. The path points at a field within each element; the innermost array on the path is filtered, and every element whose leaf field value satisfies the given matcher (or equals the given String) is removed before comparison. Intermediate collections are traversed transparently, so a path such as `entry.resource.meta.tag.system` filters the `tag` array of every `entry`. Works with `sameBeanAs` and `sameJsonAsApproved`. See [ignoring-fields](docs/ignoring-fields.md).
+
 Version 1.4.0 - 2026/06/29
 -----
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For Gradle, replace the `<dependency>` blocks with the equivalent `testImplement
 | [sameBeanAs](docs/same-bean-as.md) | Bean-to-bean comparison |
 | [sameJsonAsApproved](docs/same-json-as-approved.md) | JSON approval workflow and file naming |
 | [sameContentAsApproved](docs/same-content-as-approved.md) | Raw-text approval workflow |
-| [Ignoring fields](docs/ignoring-fields.md) | `.ignoring()` by path, Hamcrest matcher, or type |
+| [Ignoring fields](docs/ignoring-fields.md) | `.ignoring()` by path, Hamcrest matcher, or type; `.ignoringElementsWhere()` to drop array elements by value |
 | [Custom matching](docs/custom-matching.md) | `.with(path, matcher)` for field-level assertions |
 | [Sorting](docs/sorting.md) | Stable collection ordering |
 | [Aliasing](docs/aliasing.md) | Replace volatile values with readable placeholders |

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ElementIgnoreRule.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/ElementIgnoreRule.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 Shazam Entertainment Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.karsaig.approvalcrest;
+
+import com.google.gson.JsonElement;
+import org.hamcrest.Matcher;
+
+/**
+ * A rule describing array elements to remove before comparison. The {@code path} points at a
+ * field <em>within each element</em> of an array; the innermost array on the path is the one
+ * filtered. An element is removed when the value of that leaf field satisfies the rule.
+ *
+ * @see FieldsIgnorer#removeMatchingElements
+ */
+public class ElementIgnoreRule {
+
+    private final String path;
+    private final Matcher<?> valueMatcher;
+    private final String value;
+
+    private ElementIgnoreRule(String path, Matcher<?> valueMatcher, String value) {
+        this.path = path;
+        this.valueMatcher = valueMatcher;
+        this.value = value;
+    }
+
+    /**
+     * Remove elements whose leaf field value (coerced to a Java value) satisfies the matcher.
+     */
+    public static ElementIgnoreRule of(String path, Matcher<?> valueMatcher) {
+        return new ElementIgnoreRule(path, valueMatcher, null);
+    }
+
+    /**
+     * Remove elements whose leaf field, coerced to a String, equals {@code value}.
+     */
+    public static ElementIgnoreRule ofValue(String path, String value) {
+        return new ElementIgnoreRule(path, null, value);
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Whether the given leaf field element satisfies this rule and its containing element should
+     * therefore be removed.
+     */
+    public boolean matches(JsonElement leaf) {
+        if (leaf == null) {
+            return false;
+        }
+        if (valueMatcher != null) {
+            return valueMatcher.matches(JsonElementUtil.jsonElementToJavaValue(leaf));
+        }
+        return leaf.isJsonPrimitive() && value.equals(leaf.getAsString());
+    }
+}

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/FieldsIgnorer.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/FieldsIgnorer.java
@@ -213,6 +213,87 @@ public class FieldsIgnorer {
         }
     }
 
+    /**
+     * Remove array elements matching the given rules. Each rule's path points at a field within
+     * an array's elements; the innermost array on the path is filtered. Intermediate arrays are
+     * traversed transparently (fan-out), so a path such as {@code entry.resource.meta.tag.system}
+     * filters the {@code tag} array of every {@code entry}. Missing, empty or non-array paths are
+     * a silent no-op; an element without the leaf field, or that is not a JSON object, is kept.
+     */
+    public static void removeMatchingElements(JsonElement root, List<ElementIgnoreRule> rules, IgnoredFieldsTracker tracker) {
+        if (root == null || root.isJsonNull() || rules == null || rules.isEmpty()) {
+            return;
+        }
+        for (ElementIgnoreRule rule : rules) {
+            List<String> segments = asList(rule.getPath().split(PATH_SEPARATOR_PATTERN));
+            if (segments.isEmpty()) {
+                continue;
+            }
+            String leafField = segments.get(segments.size() - 1);
+            List<String> prefix = segments.subList(0, segments.size() - 1);
+            removeMatchingElements(root, prefix, leafField, rule, tracker, "");
+        }
+    }
+
+    private static void removeMatchingElements(JsonElement element, List<String> prefix, String leafField,
+                                               ElementIgnoreRule rule, IgnoredFieldsTracker tracker, String currentPath) {
+        if (element == null || element.isJsonNull()) {
+            return;
+        }
+        if (element.isJsonArray()) {
+            if (prefix.isEmpty()) {
+                filterArray(element.getAsJsonArray(), leafField, rule, tracker, currentPath);
+            } else {
+                for (JsonElement child : element.getAsJsonArray()) {
+                    removeMatchingElements(child, prefix, leafField, rule, tracker, currentPath);
+                }
+            }
+            return;
+        }
+        if (prefix.isEmpty() || !element.isJsonObject()) {
+            return;
+        }
+        JsonObject jo = element.getAsJsonObject();
+        String field = headOf(prefix);
+        List<String> tail = prefix.subList(1, prefix.size());
+        String childPath = currentPath.isEmpty() ? field : currentPath + "." + field;
+        JsonElement child = getChild(jo, field);
+        if (child != null) {
+            removeMatchingElements(child, tail, leafField, rule, tracker, childPath);
+        } else {
+            // Descend through GraphAdapter envelope keys transparently.
+            for (Map.Entry<String, JsonElement> entry : jo.entrySet()) {
+                if (isGraphAdapterKey(entry.getKey()) && entry.getValue().isJsonObject()) {
+                    removeMatchingElements(entry.getValue(), prefix, leafField, rule, tracker, currentPath);
+                }
+            }
+        }
+    }
+
+    private static void filterArray(JsonArray array, String leafField, ElementIgnoreRule rule,
+                                    IgnoredFieldsTracker tracker, String arrayPath) {
+        Iterator<JsonElement> iterator = array.iterator();
+        int idx = 0;
+        while (iterator.hasNext()) {
+            JsonElement arrayElement = iterator.next();
+            if (arrayElement.isJsonObject() && rule.matches(getChild(arrayElement.getAsJsonObject(), leafField))) {
+                iterator.remove();
+                if (tracker != null) {
+                    tracker.recordIgnored(arrayPath + "[" + idx + "]", IgnoredFieldsTracker.Reason.IGNORE_ELEMENT_MATCH);
+                }
+            }
+            idx++;
+        }
+    }
+
+    private static JsonElement getChild(JsonObject jo, String field) {
+        JsonElement child = jo.get(field);
+        if (child == null) {
+            child = jo.get(MARKER + field);
+        }
+        return child;
+    }
+
     public static void applySorting(JsonElement jsonElement, Map<String, List<SortField<String>>> pathsToSort, List<SortField<Matcher<String>>> fieldMatchersToSort, boolean sortFile) {
         applySorting(jsonElement, pathsToSort, fieldMatchersToSort, sortFile, null);
     }

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/MatcherConfiguration.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/MatcherConfiguration.java
@@ -33,6 +33,7 @@ public class MatcherConfiguration {
     private final List<SortField<Matcher<String>>> patternsToSort = new ArrayList<>();
     private final List<Class<?>> typesToSort = new ArrayList<>();
     private final List<AbstractMap.SimpleEntry<Matcher<String>, Matcher<?>>> customMatcherPatterns = new ArrayList<>();
+    private final List<ElementIgnoreRule> elementIgnoreRules = new ArrayList<>();
     private AliasMap aliasMap = AliasMap.builder().build();
     private boolean serializeNulls = getBooleanProperties("true", SERIALIZE_NULLS_PROPERTY, SERIALIZE_NULLS_ALIAS);
 
@@ -74,6 +75,20 @@ public class MatcherConfiguration {
 
     public List<AbstractMap.SimpleEntry<Matcher<String>, Matcher<?>>> getCustomMatcherPatterns() {
         return customMatcherPatterns;
+    }
+
+    public List<ElementIgnoreRule> getElementIgnoreRules() {
+        return elementIgnoreRules;
+    }
+
+    public MatcherConfiguration addElementIgnoreRule(String path, Matcher<?> valueMatcher) {
+        elementIgnoreRules.add(ElementIgnoreRule.of(path, valueMatcher));
+        return this;
+    }
+
+    public MatcherConfiguration addElementIgnoreRule(String path, String value) {
+        elementIgnoreRules.add(ElementIgnoreRule.ofValue(path, value));
+        return this;
     }
 
     public MatcherConfiguration addPathToIgnore(String path) {

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/CustomisableMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/CustomisableMatcher.java
@@ -89,6 +89,35 @@ public interface CustomisableMatcher<T, U extends CustomisableMatcher<T, U>> ext
     <V> U withMatcher(Matcher<String> fieldNamePattern, Matcher<V> matcher);
 
     /**
+     * Remove array elements from the comparison based on the value of a nested field. The path
+     * points at a field <em>within each element</em> of an array; the innermost array on the path
+     * is the one filtered. Every element whose leaf field value satisfies {@code valueMatcher} is
+     * removed before comparison. Intermediate collections are traversed transparently (fan-out),
+     * so a path such as {@code entry.resource.meta.tag.system} filters the {@code tag} array of
+     * every {@code entry}. Missing, empty or non-array paths are a silent no-op.
+     * Example:
+     * <pre>sameJsonAsApproved().ignoringElementsWhere("meta.tag.system", equalTo(FLOW_ID_TAG_SYSTEM))</pre>
+     *
+     * @param elementFieldPath the dot-separated path to the field within each array element.
+     * @param valueMatcher     the Hamcrest matcher applied to that field's value to select elements
+     *                         for removal.
+     * @return the instance of the matcher
+     */
+    U ignoringElementsWhere(String elementFieldPath, Matcher<?> valueMatcher);
+
+    /**
+     * Convenience form of {@link #ignoringElementsWhere(String, Matcher)} that removes elements
+     * whose leaf field, coerced to a String, equals {@code value}.
+     * Example:
+     * <pre>sameJsonAsApproved().ignoringElementsWhere("meta.tag.system", FLOW_ID_TAG_SYSTEM)</pre>
+     *
+     * @param elementFieldPath the dot-separated path to the field within each array element.
+     * @param value            the value to compare the field's coerced String value against.
+     * @return the instance of the matcher
+     */
+    U ignoringElementsWhere(String elementFieldPath, String value);
+
+    /**
      * Specify a custom configuration for the Gson, for example, providing additional TypeAdapters.
      *
      * @param configuration {@link GsonConfiguration} object, containing TypeAdapterFactories, TypeAdapters and

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/DiagnosingCustomisableMatcher.java
@@ -36,6 +36,7 @@ import static com.github.karsaig.approvalcrest.EnvVarReader.getBooleanProperties
 import static com.github.karsaig.approvalcrest.FieldsIgnorer.applySorting;
 import static com.github.karsaig.approvalcrest.FieldsIgnorer.applyRootCollectionSorting;
 import static com.github.karsaig.approvalcrest.FieldsIgnorer.findPaths;
+import static com.github.karsaig.approvalcrest.FieldsIgnorer.removeMatchingElements;
 import static com.github.karsaig.approvalcrest.FieldsIgnorer.removeSetMarker;
 import static com.github.karsaig.approvalcrest.matcher.GsonProvider.gson;
 
@@ -155,6 +156,18 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
     }
 
     @Override
+    public DiagnosingCustomisableMatcher<T> ignoringElementsWhere(String elementFieldPath, Matcher<?> valueMatcher) {
+        matcherConfiguration.addElementIgnoreRule(elementFieldPath, valueMatcher);
+        return this;
+    }
+
+    @Override
+    public DiagnosingCustomisableMatcher<T> ignoringElementsWhere(String elementFieldPath, String value) {
+        matcherConfiguration.addElementIgnoreRule(elementFieldPath, value);
+        return this;
+    }
+
+    @Override
     public DiagnosingCustomisableMatcher<T> withGsonConfiguration(GsonConfiguration configuration) {
         this.configuration = configuration;
         return this;
@@ -195,6 +208,7 @@ public class DiagnosingCustomisableMatcher<T> extends AbstractDiagnosingMatcher<
         }
 
         JsonElement filteredJson = findPaths(preComputedJson, set, tracker, reasonMap);
+        removeMatchingElements(filteredJson, matcherConfiguration.getElementIgnoreRules(), tracker);
         JsonElementUtil.filterByCustomMatcherPatterns(filteredJson, matcherConfiguration, tracker);
         AliasMap aliasMap = matcherConfiguration.getAliasMap();
         if (!aliasMap.isEmpty()) {

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/JsonMatcher.java
@@ -110,6 +110,18 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
     }
 
     @Override
+    public JsonMatcher<T> ignoringElementsWhere(String elementFieldPath, Matcher<?> valueMatcher) {
+        matcherConfiguration.addElementIgnoreRule(elementFieldPath, valueMatcher);
+        return this;
+    }
+
+    @Override
+    public JsonMatcher<T> ignoringElementsWhere(String elementFieldPath, String value) {
+        matcherConfiguration.addElementIgnoreRule(elementFieldPath, value);
+        return this;
+    }
+
+    @Override
     public JsonMatcher<T> withGsonConfiguration(GsonConfiguration configuration) {
         this.configuration = configuration;
         return this;
@@ -213,6 +225,7 @@ public class JsonMatcher<T> extends AbstractDiagnosingFileMatcher<T, JsonMatcher
         JsonElement filteredJson = findPaths(jsonElement, set, ignoredTracker, reasonMap);
         JsonElementUtil.filterByFieldMatchers(filteredJson, skipIgnores ? emptyList() : matcherConfiguration.getPatternsToIgnore(), ignoredTracker, Reason.IGNORE_PATTERN);
         if (!skipIgnores) {
+            removeMatchingElements(filteredJson, matcherConfiguration.getElementIgnoreRules(), ignoredTracker);
             JsonElementUtil.filterByCustomMatcherPatterns(filteredJson, matcherConfiguration, ignoredTracker);
         }
         AliasMap aliasMap = matcherConfiguration.getAliasMap();

--- a/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/IgnoredFieldsTracker.java
+++ b/approvalcrest-core/src/main/java/com/github/karsaig/approvalcrest/matcher/machinereadable/IgnoredFieldsTracker.java
@@ -15,6 +15,7 @@ public class IgnoredFieldsTracker {
         IGNORE_PATTERN,
         CUSTOM_MATCHER,
         CUSTOM_MATCHER_PATTERN,
+        IGNORE_ELEMENT_MATCH,
         REMOVED_EMPTY
     }
 

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/ignores/BeanMatcherIgnoreElementsTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/ignores/BeanMatcherIgnoreElementsTest.java
@@ -1,0 +1,225 @@
+package com.github.karsaig.approvalcrest.matcher.ignores;
+
+import com.github.karsaig.approvalcrest.matcher.AbstractBeanMatcherTest;
+import com.github.karsaig.approvalcrest.matcher.DiagnosingCustomisableMatcher;
+import com.github.karsaig.approvalcrest.matcher.TestMatcherFactory;
+import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * Tests for {@code ignoringElementsWhere} on {@code sameBeanAs}. The fixtures mirror the FHIR
+ * JSON shape ({@code meta.tag} = array of {@code {system, code, display}}) that motivated the
+ * feature: a runtime "tracking tag" that must be removed before comparison.
+ */
+public class BeanMatcherIgnoreElementsTest extends AbstractBeanMatcherTest {
+
+    private static final String TRACKING_SYSTEM = "https://tracking.example/flow-id";
+    private static final String REAL_SYSTEM = "https://real.example/category";
+
+    @Test
+    void matcherFormRemovesOnlyTheMatchingElement() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(TRACKING_SYSTEM, "flow-123"),
+                new Tag(REAL_SYSTEM, "keep"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)));
+    }
+
+    @Test
+    void stringValueFormRemovesOnlyTheMatchingElement() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(TRACKING_SYSTEM, "flow-123"),
+                new Tag(REAL_SYSTEM, "keep"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("meta.tag.system", TRACKING_SYSTEM));
+    }
+
+    @Test
+    void removesEveryMatchingElementAndKeepsOthersInOrder() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(TRACKING_SYSTEM, "flow-1"),
+                new Tag(REAL_SYSTEM, "first"),
+                new Tag(TRACKING_SYSTEM, "flow-2"),
+                new Tag(REAL_SYSTEM, "second"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "first"),
+                new Tag(REAL_SYSTEM, "second"))));
+
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)));
+    }
+
+    @Test
+    void allElementsRemovedLeavesEmptyArray() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(TRACKING_SYSTEM, "flow-1"),
+                new Tag(TRACKING_SYSTEM, "flow-2"))));
+        Resource expected = new Resource(new Meta(Lists.<Tag>newArrayList()));
+
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)));
+    }
+
+    @Test
+    void fanOutThroughBundleRemovesTagNotEntry() {
+        Bundle actual = new Bundle(Lists.newArrayList(
+                new Entry(new Resource(new Meta(Lists.newArrayList(
+                        new Tag(TRACKING_SYSTEM, "flow-1"),
+                        new Tag(REAL_SYSTEM, "keep-1"))))),
+                new Entry(new Resource(new Meta(Lists.newArrayList(
+                        new Tag(REAL_SYSTEM, "keep-2")))))));
+        Bundle expected = new Bundle(Lists.newArrayList(
+                new Entry(new Resource(new Meta(Lists.newArrayList(
+                        new Tag(REAL_SYSTEM, "keep-1"))))),
+                new Entry(new Resource(new Meta(Lists.newArrayList(
+                        new Tag(REAL_SYSTEM, "keep-2")))))));
+
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("entry.resource.meta.tag.system", equalTo(TRACKING_SYSTEM)));
+    }
+
+    @Test
+    void matcherFormSupportsRichMatchers() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(TRACKING_SYSTEM, "flow-1"),
+                new Tag(REAL_SYSTEM, "keep"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("meta.tag.system", startsWith("https://tracking")));
+    }
+
+    @Test
+    void withoutRuleTheExtraElementFailsTheComparison() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(TRACKING_SYSTEM, "flow-123"),
+                new Tag(REAL_SYSTEM, "keep"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+
+        assertDiagnosingMatcher(actual, expected, DiagnosingCustomisableMatcher::skipClassComparison,
+                AssertionFailedError.class,
+                thrown -> Assertions.assertTrue(thrown.getMessage().contains("tag"),
+                        "failure should report the tag array difference: " + thrown.getMessage()));
+    }
+
+    @Test
+    void nonMatchingValueIsANoOp() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+
+        // No element has the tracking system, so nothing is removed and the beans still match.
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)));
+    }
+
+    @Test
+    void missingPathIsANoOp() {
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "keep"))));
+
+        assertDiagnosingMatcher(actual, expected,
+                m -> m.ignoringElementsWhere("does.not.exist", equalTo(TRACKING_SYSTEM)));
+    }
+
+    @Test
+    void machineReadableOutputListsRemovedElement() {
+        // Actual carries a tracking tag (removed) and a real tag whose code differs from expected,
+        // so the comparison still fails and the machine-readable output is produced.
+        Resource actual = new Resource(new Meta(Lists.newArrayList(
+                new Tag(TRACKING_SYSTEM, "flow-123"),
+                new Tag(REAL_SYSTEM, "actual-code"))));
+        Resource expected = new Resource(new Meta(Lists.newArrayList(
+                new Tag(REAL_SYSTEM, "expected-code"))));
+
+        DiagnosingCustomisableMatcher<Resource> underTest = new TestMatcherFactory()
+                .beanMatcher(expected)
+                .ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM))
+                .withMachineReadableOutput();
+
+        AssertionFailedError error = Assertions.assertThrows(AssertionFailedError.class,
+                () -> assertThat(actual, underTest));
+
+        JsonObject json = JsonParser.parseString(error.getMessage()).getAsJsonObject();
+        JsonArray ignored = json.getAsJsonArray("ignoredFields");
+        boolean found = false;
+        for (JsonElement e : ignored) {
+            JsonObject o = e.getAsJsonObject();
+            if ("IGNORE_ELEMENT_MATCH".equals(o.get("reason").getAsString())
+                    && o.get("path").getAsString().startsWith("meta.tag[")) {
+                found = true;
+            }
+        }
+        Assertions.assertTrue(found,
+                "ignoredFields should list the removed element with reason IGNORE_ELEMENT_MATCH: " + ignored);
+    }
+
+    @SuppressWarnings("unused")
+    private static class Bundle {
+        private final List<Entry> entry;
+
+        Bundle(List<Entry> entry) {
+            this.entry = entry;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Entry {
+        private final Resource resource;
+
+        Entry(Resource resource) {
+            this.resource = resource;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Resource {
+        private final Meta meta;
+
+        Resource(Meta meta) {
+            this.meta = meta;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Meta {
+        private final List<Tag> tag;
+
+        Meta(List<Tag> tag) {
+            this.tag = tag;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Tag {
+        private final String system;
+        private final String code;
+
+        Tag(String system, String code) {
+            this.system = system;
+            this.code = code;
+        }
+    }
+}

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/ignores/JsonMatcherIgnoreElementsTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/ignores/JsonMatcherIgnoreElementsTest.java
@@ -1,0 +1,97 @@
+package com.github.karsaig.approvalcrest.matcher.ignores;
+
+import com.github.karsaig.approvalcrest.matcher.AbstractFileMatcherTest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for {@code ignoringElementsWhere} on {@code sameJsonAsApproved}. Inputs are FHIR-shaped
+ * JSON strings ({@code meta.tag} = array of {@code {system, code}}). In strict file matching the
+ * rule strips elements from the actual side only, so the approved content must already omit them;
+ * in lenient matching the rule strips both sides, so an approved file that still contains the
+ * element also passes.
+ */
+public class JsonMatcherIgnoreElementsTest extends AbstractFileMatcherTest {
+
+    private static final String TRACKING_SYSTEM = "https://tracking.example/flow-id";
+    private static final String REAL_SYSTEM = "https://real.example/category";
+
+    private static final String INPUT_WITH_TRACKING_TAG = "{\n" +
+            "  \"meta\": {\n" +
+            "    \"tag\": [\n" +
+            "      { \"code\": \"flow-123\", \"system\": \"" + TRACKING_SYSTEM + "\" },\n" +
+            "      { \"code\": \"keep\", \"system\": \"" + REAL_SYSTEM + "\" }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"resourceType\": \"Patient\"\n" +
+            "}";
+
+    private static final String APPROVED_WITHOUT_TRACKING_TAG = "{\n" +
+            "  \"meta\": {\n" +
+            "    \"tag\": [\n" +
+            "      { \"code\": \"keep\", \"system\": \"" + REAL_SYSTEM + "\" }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"resourceType\": \"Patient\"\n" +
+            "}";
+
+    @Test
+    void strictMatchingStripsTrackingTagFromActualOnly() {
+        assertJsonMatcherWithDummyTestInfo(INPUT_WITH_TRACKING_TAG, APPROVED_WITHOUT_TRACKING_TAG,
+                getDefaultFileMatcherConfig(),
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)), null);
+    }
+
+    @Test
+    void stringValueFormStripsTrackingTag() {
+        assertJsonMatcherWithDummyTestInfo(INPUT_WITH_TRACKING_TAG, APPROVED_WITHOUT_TRACKING_TAG,
+                getDefaultFileMatcherConfig(),
+                m -> m.ignoringElementsWhere("meta.tag.system", TRACKING_SYSTEM), null);
+    }
+
+    @Test
+    void lenientMatchingStripsTrackingTagFromBothSides() {
+        // Approved file still contains the tracking tag; lenient matching filters it from the
+        // approved side too, so the assertion passes.
+        assertJsonMatcherWithDummyTestInfo(INPUT_WITH_TRACKING_TAG, INPUT_WITH_TRACKING_TAG,
+                getDefaultFileMatcherConfigWithLenientMatching(),
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)), null);
+    }
+
+    @Test
+    void allElementsRemovedLeavesEmptyArray() {
+        String inputAllTracking = "{\n" +
+                "  \"meta\": {\n" +
+                "    \"tag\": [\n" +
+                "      { \"code\": \"flow-1\", \"system\": \"" + TRACKING_SYSTEM + "\" },\n" +
+                "      { \"code\": \"flow-2\", \"system\": \"" + TRACKING_SYSTEM + "\" }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"resourceType\": \"Patient\"\n" +
+                "}";
+        String approvedEmptyTag = "{\n" +
+                "  \"meta\": {\n" +
+                "    \"tag\": []\n" +
+                "  },\n" +
+                "  \"resourceType\": \"Patient\"\n" +
+                "}";
+
+        assertJsonMatcherWithDummyTestInfo(inputAllTracking, approvedEmptyTag,
+                getDefaultFileMatcherConfig(),
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)), null);
+    }
+
+    @Test
+    void strictMatchingFailsWhenApprovedStillContainsTrackingTag() {
+        // Strict matching does not touch the approved side, so an approved file that still
+        // contains the tracking tag no longer matches the stripped actual.
+        assertJsonMatcherWithDummyTestInfo(INPUT_WITH_TRACKING_TAG, INPUT_WITH_TRACKING_TAG,
+                getDefaultFileMatcherConfig(),
+                m -> m.ignoringElementsWhere("meta.tag.system", equalTo(TRACKING_SYSTEM)),
+                thrown -> org.junit.jupiter.api.Assertions.assertTrue(
+                        thrown.getMessage().contains("tag"),
+                        "failure should report the tag difference: " + thrown.getMessage()),
+                AssertionError.class);
+    }
+}

--- a/approvalcrest-junit-jupiter-kotlin/src/main/kotlin/com/github/karsaig/approvalcrest/kotlin/matcher/DiagnosingCustomisableMatcherExtensions.kt
+++ b/approvalcrest-junit-jupiter-kotlin/src/main/kotlin/com/github/karsaig/approvalcrest/kotlin/matcher/DiagnosingCustomisableMatcherExtensions.kt
@@ -53,6 +53,14 @@ fun <T, V> DiagnosingCustomisableMatcher<T>.withMatcher(fieldNamePattern: Matche
     (this as CustomisableMatcher<T, DiagnosingCustomisableMatcher<T>>).withMatcher(fieldNamePattern, matcher)
 
 @Suppress("UNCHECKED_CAST")
+fun <T> DiagnosingCustomisableMatcher<T>.ignoringElementsWhere(elementFieldPath: String, valueMatcher: Matcher<*>): DiagnosingCustomisableMatcher<T> =
+    (this as CustomisableMatcher<T, DiagnosingCustomisableMatcher<T>>).ignoringElementsWhere(elementFieldPath, valueMatcher)
+
+@Suppress("UNCHECKED_CAST")
+fun <T> DiagnosingCustomisableMatcher<T>.ignoringElementsWhere(elementFieldPath: String, value: String): DiagnosingCustomisableMatcher<T> =
+    (this as CustomisableMatcher<T, DiagnosingCustomisableMatcher<T>>).ignoringElementsWhere(elementFieldPath, value)
+
+@Suppress("UNCHECKED_CAST")
 fun <T> DiagnosingCustomisableMatcher<T>.withGsonConfiguration(configuration: GsonConfiguration): DiagnosingCustomisableMatcher<T> =
     (this as CustomisableMatcher<T, DiagnosingCustomisableMatcher<T>>).withGsonConfiguration(configuration)
 

--- a/approvalcrest-junit-jupiter-kotlin/src/main/kotlin/com/github/karsaig/approvalcrest/kotlin/matcher/JsonMatcherExtensions.kt
+++ b/approvalcrest-junit-jupiter-kotlin/src/main/kotlin/com/github/karsaig/approvalcrest/kotlin/matcher/JsonMatcherExtensions.kt
@@ -54,6 +54,14 @@ fun <T, V> JsonMatcher<T>.withMatcher(fieldNamePattern: Matcher<String>, matcher
     (this as CustomisableMatcher<T, JsonMatcher<T>>).withMatcher(fieldNamePattern, matcher)
 
 @Suppress("UNCHECKED_CAST")
+fun <T> JsonMatcher<T>.ignoringElementsWhere(elementFieldPath: String, valueMatcher: Matcher<*>): JsonMatcher<T> =
+    (this as CustomisableMatcher<T, JsonMatcher<T>>).ignoringElementsWhere(elementFieldPath, valueMatcher)
+
+@Suppress("UNCHECKED_CAST")
+fun <T> JsonMatcher<T>.ignoringElementsWhere(elementFieldPath: String, value: String): JsonMatcher<T> =
+    (this as CustomisableMatcher<T, JsonMatcher<T>>).ignoringElementsWhere(elementFieldPath, value)
+
+@Suppress("UNCHECKED_CAST")
 fun <T> JsonMatcher<T>.withGsonConfiguration(configuration: GsonConfiguration): JsonMatcher<T> =
     (this as CustomisableMatcher<T, JsonMatcher<T>>).withGsonConfiguration(configuration)
 

--- a/approvalcrest-junit-jupiter-kotlin/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/ExtensionFunctionsTest.kt
+++ b/approvalcrest-junit-jupiter-kotlin/src/test/kotlin/com/github/karsaig/approvalcrest/kotlin/ExtensionFunctionsTest.kt
@@ -2,9 +2,11 @@ package com.github.karsaig.approvalcrest.kotlin
 
 import com.github.karsaig.approvalcrest.jupiter.MatcherAssert.assertThat
 import com.github.karsaig.approvalcrest.kotlin.matcher.Matchers
+import com.github.karsaig.approvalcrest.kotlin.matcher.ignoringElementsWhere
 import com.github.karsaig.approvalcrest.kotlin.matcher.sortType
 import com.github.karsaig.approvalcrest.kotlin.matcher.withMachineReadableOutput
 import com.github.karsaig.approvalcrest.kotlin.matcher.withoutSerializingNulls
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
@@ -82,6 +84,26 @@ class ExtensionFunctionsTest {
         val matcher = Matchers.sameJsonAsApproved<TestBean>().sortType(String::class.java)
         assertNotNull(matcher)
     }
+
+    @Test
+    fun ignoringElementsWhereCanBeChainedOnBeanMatcher() {
+        val actual = MetaBean(listOf(Tag("tracking", "flow-1"), Tag("real", "keep")))
+        val expected = MetaBean(listOf(Tag("real", "keep")))
+        val matcher = Matchers.sameBeanAs(expected)
+            .ignoringElementsWhere("tag.system", equalTo("tracking"))
+        assertNotNull(matcher)
+        assertThat(actual, matcher)
+    }
+
+    @Test
+    fun ignoringElementsWhereStringFormCanBeChainedOnJsonMatcher() {
+        val matcher = Matchers.sameJsonAsApproved<MetaBean>()
+            .ignoringElementsWhere("tag.system", "tracking")
+        assertNotNull(matcher)
+    }
+
+    private data class Tag(val system: String, val code: String)
+    private data class MetaBean(val tag: List<Tag>)
 
     @Test
     fun withMachineReadableOutputCanBeChainedOnContentMatcher() {

--- a/approvalcrest-junit-jupiter/src/test/java/com/github/karsaig/approvalcrest/matcher/json/ignore/IgnoreElementsWhereTest.java
+++ b/approvalcrest-junit-jupiter/src/test/java/com/github/karsaig/approvalcrest/matcher/json/ignore/IgnoreElementsWhereTest.java
@@ -1,0 +1,49 @@
+package com.github.karsaig.approvalcrest.matcher.json.ignore;
+
+import static com.github.karsaig.approvalcrest.jupiter.MatcherAssert.assertThat;
+import static com.github.karsaig.approvalcrest.jupiter.matcher.Matchers.sameBeanAs;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Smoke test that {@code ignoringElementsWhere} is reachable through the JUnit 5 (Jupiter) module.
+ * The behaviour itself is covered in depth in {@code approvalcrest-core}.
+ */
+public class IgnoreElementsWhereTest {
+
+    private static final String TRACKING_SYSTEM = "https://tracking.example/flow-id";
+    private static final String REAL_SYSTEM = "https://real.example/category";
+
+    @Test
+    public void removesArrayElementsMatchingValue() {
+        Meta actual = new Meta(Arrays.asList(new Tag(TRACKING_SYSTEM, "flow-1"), new Tag(REAL_SYSTEM, "keep")));
+        Meta expected = new Meta(Arrays.asList(new Tag(REAL_SYSTEM, "keep")));
+
+        assertThat(actual, sameBeanAs(expected).ignoringElementsWhere("tag.system", equalTo(TRACKING_SYSTEM)));
+        assertThat(actual, sameBeanAs(expected).ignoringElementsWhere("tag.system", TRACKING_SYSTEM));
+    }
+
+    @SuppressWarnings("unused")
+    private static class Meta {
+        private final List<Tag> tag;
+
+        Meta(List<Tag> tag) {
+            this.tag = tag;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Tag {
+        private final String system;
+        private final String code;
+
+        Tag(String system, String code) {
+            this.system = system;
+            this.code = code;
+        }
+    }
+}

--- a/approvalcrest-testng/src/test/java/com/github/karsaig/approvalcrest/testng/IgnoreElementsWhereTest.java
+++ b/approvalcrest-testng/src/test/java/com/github/karsaig/approvalcrest/testng/IgnoreElementsWhereTest.java
@@ -1,0 +1,49 @@
+package com.github.karsaig.approvalcrest.testng;
+
+import static com.github.karsaig.approvalcrest.testng.MatcherAssert.assertThat;
+import static com.github.karsaig.approvalcrest.testng.matcher.Matchers.sameBeanAs;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+/**
+ * Smoke test that {@code ignoringElementsWhere} is reachable through the TestNG module. The
+ * behaviour itself is covered in depth in {@code approvalcrest-core}.
+ */
+public class IgnoreElementsWhereTest {
+
+    private static final String TRACKING_SYSTEM = "https://tracking.example/flow-id";
+    private static final String REAL_SYSTEM = "https://real.example/category";
+
+    @Test
+    public void removesArrayElementsMatchingValue() {
+        Meta actual = new Meta(Arrays.asList(new Tag(TRACKING_SYSTEM, "flow-1"), new Tag(REAL_SYSTEM, "keep")));
+        Meta expected = new Meta(Arrays.asList(new Tag(REAL_SYSTEM, "keep")));
+
+        assertThat(actual, sameBeanAs(expected).ignoringElementsWhere("tag.system", equalTo(TRACKING_SYSTEM)));
+        assertThat(actual, sameBeanAs(expected).ignoringElementsWhere("tag.system", TRACKING_SYSTEM));
+    }
+
+    @SuppressWarnings("unused")
+    private static class Meta {
+        private final List<Tag> tag;
+
+        Meta(List<Tag> tag) {
+            this.tag = tag;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Tag {
+        private final String system;
+        private final String code;
+
+        Tag(String system, String code) {
+            this.system = system;
+            this.code = code;
+        }
+    }
+}

--- a/approvalcrest/src/test/java/com/github/karsaig/approvalcrest/matcher/json/ignore/IgnoreElementsWhereTest.java
+++ b/approvalcrest/src/test/java/com/github/karsaig/approvalcrest/matcher/json/ignore/IgnoreElementsWhereTest.java
@@ -1,0 +1,49 @@
+package com.github.karsaig.approvalcrest.matcher.json.ignore;
+
+import static com.github.karsaig.approvalcrest.MatcherAssert.assertThat;
+import static com.github.karsaig.approvalcrest.matcher.Matchers.sameBeanAs;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Smoke test that {@code ignoringElementsWhere} is reachable through the JUnit 4 module. The
+ * behaviour itself is covered in depth in {@code approvalcrest-core}.
+ */
+public class IgnoreElementsWhereTest {
+
+    private static final String TRACKING_SYSTEM = "https://tracking.example/flow-id";
+    private static final String REAL_SYSTEM = "https://real.example/category";
+
+    @Test
+    public void removesArrayElementsMatchingValue() {
+        Meta actual = new Meta(Arrays.asList(new Tag(TRACKING_SYSTEM, "flow-1"), new Tag(REAL_SYSTEM, "keep")));
+        Meta expected = new Meta(Arrays.asList(new Tag(REAL_SYSTEM, "keep")));
+
+        assertThat(actual, sameBeanAs(expected).ignoringElementsWhere("tag.system", equalTo(TRACKING_SYSTEM)));
+        assertThat(actual, sameBeanAs(expected).ignoringElementsWhere("tag.system", TRACKING_SYSTEM));
+    }
+
+    @SuppressWarnings("unused")
+    private static class Meta {
+        private final List<Tag> tag;
+
+        Meta(List<Tag> tag) {
+            this.tag = tag;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Tag {
+        private final String system;
+        private final String code;
+
+        Tag(String system, String code) {
+            this.system = system;
+            this.code = code;
+        }
+    }
+}

--- a/docs/ignoring-fields.md
+++ b/docs/ignoring-fields.md
@@ -2,7 +2,7 @@
 
 # ignoring-fields
 
-Exclude specific fields from comparison using path, Hamcrest matcher, or type.
+Exclude specific fields from comparison using path, Hamcrest matcher, or type — or remove whole array elements by value with `ignoringElementsWhere`.
 
 Works with `sameBeanAs` and `sameJsonAsApproved`. Multiple `.ignoring()` calls can be chained.
 
@@ -59,6 +59,42 @@ assertThat(actual, sameJsonAsApproved()
 ```
 
 This works identically whether the type is `List`, `Set`, any `Collection` subtype, or a JSON array. Paths through empty collections do nothing silently.
+
+## Removing Array Elements by Value
+
+`.ignoring()` removes *fields*; it cannot drop an individual array element based on what that element contains. `.ignoringElementsWhere()` fills that gap: it removes the array elements whose nested field has a given value.
+
+The path points at a field **within each element**. The **innermost array on the path** is the one filtered — every element whose leaf field value satisfies the matcher is removed:
+
+```java
+import static org.hamcrest.Matchers.equalTo;
+
+// meta.tag is an array of { system, code, ... }; remove the elements
+// whose system is the tracking system, keeping the rest of the array.
+assertThat(actual, sameJsonAsApproved()
+    .ignoringElementsWhere("meta.tag.system", equalTo(FLOW_ID_TAG_SYSTEM)));
+```
+
+Any `Matcher` works (`startsWith`, `greaterThan`, `not(...)`, …). A convenience overload takes a plain `String`, matching the field's value coerced to a String:
+
+```java
+assertThat(actual, sameJsonAsApproved()
+    .ignoringElementsWhere("meta.tag.system", FLOW_ID_TAG_SYSTEM));
+```
+
+Like the other ignore styles, the path fans out through intermediate collections, so it works for nested structures such as a FHIR `Bundle` — this removes matching `tag` elements from every entry's resource, not the entries themselves:
+
+```java
+assertThat(actual, sameJsonAsApproved()
+    .ignoringElementsWhere("entry.resource.meta.tag.system", equalTo(FLOW_ID_TAG_SYSTEM)));
+```
+
+Behaviour:
+
+- Matching happens against the **serialized JSON** field names. When the input is a JSON string (or a value that serializes with those names) the path is written exactly as it appears in the JSON. Objects that serialize under different internal names (for example raw library model objects with a custom Gson `TypeAdapter`) must expose the JSON-level names for the path to match.
+- If **all** elements match, the array is left empty (`[]`) rather than removed — the approved file is expected to contain the empty array after regeneration.
+- An element without the leaf field, or that is not a JSON object, is kept. A missing, empty or non-array path is a silent no-op.
+- In strict file matching (the default), elements are removed from the **actual** side only, so the approved file must be regenerated to drop them — identical to how `.ignoring()` behaves.
 
 ## By Hamcrest Matcher on Field Name
 


### PR DESCRIPTION
Introduce ignoringElementsWhere(path, matcher) and a String-value convenience overload on CustomisableMatcher, letting tests remove array elements from the comparison based on the value of a nested field (e.g. a FHIR meta.tag whose system is a runtime tracking tag). The path points at a field within each element; the innermost array on the path is filtered, and intermediate collections are traversed transparently (fan-out). Works with sameBeanAs and sameJsonAsApproved, and is gated on strict file matching exactly like the other ignore variants.

Includes core logic (FieldsIgnorer.removeMatchingElements + ElementIgnoreRule), machine-readable IGNORE_ELEMENT_MATCH tracking, Kotlin extensions, tests for both matchers, and docs/CHANGELOG updates.