### PR TITLE
Add JaCoCo code coverage measurement with Codecov reporting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -74,6 +74,26 @@ jobs:
           set | grep JAVA
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Djava.version.to.run="${{ matrix.java }}"
+  coverage:
+    name: Code coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          cache: maven
+      - name: Build with coverage
+        run: mvn -B verify -Pcoverage --file pom.xml -Djava.version.to.run=25
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: approvalcrest-coverage-report/target/site/jacoco-aggregate/jacoco.xml
+          fail_ci_if_error: false
   build-JDK_25:
     name: Java ${{ matrix.java }} build on JDK 25
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Approvalcrest
 ===========
 [![Java CI with Maven](https://github.com/karsaig/approvalcrest/actions/workflows/maven.yml/badge.svg)](https://github.com/karsaig/approvalcrest/actions/workflows/maven.yml)
+[![codecov](https://codecov.io/gh/karsaig/approvalcrest/graph/badge.svg)](https://codecov.io/gh/karsaig/approvalcrest)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.karsaig/approvalcrest.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.karsaig%22%20AND%20a:%22approvalcrest%22)
 
 ## Contents

--- a/approvalcrest-core/pom.xml
+++ b/approvalcrest-core/pom.xml
@@ -135,6 +135,7 @@
                                 <exclude>**/ReflectModeFallback*.java</exclude>
                             </excludes>
                             <argLine>
+                                @{argLine}
                                 -Dfile.encoding=UTF-8
                                 -DapprovalcrestReflection=force
                                 --add-opens java.base/java.lang=ALL-UNNAMED
@@ -157,7 +158,7 @@
                         </goals>
                         <configuration>
                             <excludes combine.self="override"/>
-                            <argLine>-Dfile.encoding=UTF-8 -DapprovalcrestReflection=fallback</argLine>
+                            <argLine>@{argLine} -Dfile.encoding=UTF-8 -DapprovalcrestReflection=fallback</argLine>
                             <includes>
                                 <include>**/ReflectModeFallback*.java</include>
                             </includes>

--- a/approvalcrest-coverage-report/pom.xml
+++ b/approvalcrest-coverage-report/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>approvalcrest-parent</artifactId>
+        <groupId>com.github.karsaig</groupId>
+        <version>1.4.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>approvalcrest-coverage-report</artifactId>
+    <packaging>pom</packaging>
+    <name>Approvalcrest-coverage-report</name>
+    <description>Aggregated JaCoCo coverage report across all modules. Never published to Maven Central;
+        only built under the 'coverage' profile.</description>
+
+    <!--
+        This module produces a single aggregated coverage report via jacoco:report-aggregate. JaCoCo reads
+        execution data (target/jacoco.exec) and analysed classes/sources from every module listed below:
+          - the library modules contribute their production classes + sources, and
+          - the *-integration-tests modules contribute the execution data that actually exercises them
+            (their tests run in the integration-test phase, reached by 'mvn verify').
+        testing-common is intentionally omitted so test-support code does not dilute the coverage figure.
+    -->
+    <dependencies>
+        <!-- Library modules: production classes + sources to analyse. -->
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-dedup</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-junit-jupiter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-testng</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-junit-jupiter-kotlin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Integration-test modules: execution data covering the library modules above. -->
+        <dependency>
+            <groupId>com.github.karsaig.integration.tests</groupId>
+            <artifactId>approvalcrest-integration-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig.integration.tests</groupId>
+            <artifactId>approvalcrest-junit-jupiter-integration-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-junit-vintage-integration-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig.integration.tests</groupId>
+            <artifactId>approvalcrest-testng-integration-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig.integration.tests</groupId>
+            <artifactId>approvalcrest-testng-integration-tests-testng6</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig.integration.tests</groupId>
+            <artifactId>approvalcrest-junit-jupiter-kotlin-integration-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- These integration-test modules only exist under the junit6* profiles (JDK >= 17). The coverage
+             build always runs on JDK 25 (java.version.to.run=25), so they are present in the reactor. -->
+        <dependency>
+            <groupId>com.github.karsaig.integration.tests</groupId>
+            <artifactId>approvalcrest-junit-jupiter-integration-tests-junit6</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig</groupId>
+            <artifactId>approvalcrest-junit-vintage-integration-tests-junit6</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.karsaig.integration.tests</groupId>
+            <artifactId>approvalcrest-jdk17-integration-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Report-only aggregation module: disable convergence enforcement, which the wide mix of
+                 junit/testng/kotlin transitive dependencies pulled in here would otherwise fail. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/for-release-pom.xml
+++ b/for-release-pom.xml
@@ -27,6 +27,9 @@
         <maven.shade.plugin.version>3.6.1</maven.shade.plugin.version>
         <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
         <maven.versions.plugin.version>2.21.0</maven.versions.plugin.version>
+        <!-- Empty default so the @{argLine} in approvalcrest-core's surefire executions resolves to
+             nothing during a release build (this pom never enables the coverage profile / JaCoCo agent). -->
+        <argLine></argLine>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
         <maven.versions.plugin.version>2.21.0</maven.versions.plugin.version>
         <maven.enforcer.plugin.version>3.6.3</maven.enforcer.plugin.version>
         <mockito.jupiter.version>5.23.0</mockito.jupiter.version>
+        <jacoco.plugin.version>0.8.15</jacoco.plugin.version>
+        <!-- Empty default so surefire's @{argLine} resolves cleanly when the coverage profile is inactive.
+             The coverage profile's jacoco:prepare-agent overrides this with the agent argument. -->
+        <argLine></argLine>
     </properties>
 
     <licenses>
@@ -160,7 +164,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
-                        <argLine>-Dfile.encoding=UTF-8</argLine>
+                        <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
                     </configuration>
                 </plugin>
             </plugins>
@@ -168,6 +172,29 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>coverage</id>
+            <modules>
+                <module>approvalcrest-coverage-report</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>sign-release</id>
             <build>


### PR DESCRIPTION
Aggregate coverage across all modules via a new non-published approvalcrest-coverage-report module running jacoco:report-aggregate. Everything is isolated behind a 'coverage' Maven profile so the existing build matrix is unaffected; a dedicated CI job runs 'mvn verify -Pcoverage' on JDK 25 and uploads the report to Codecov.