### PR TITLE
Close test and documentation debt from the #43 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Changelog
 ===========
 
-Version 1.5.1 - 
+Version 1.5.1 - Unreleased
 -----
 - A `*` segment no longer walks fields the serialised form does not contain. It iterated every declared field, including `static`, `transient` and compiler-generated ones, so on an enum it read the other constants off the one held, and on a non-static inner class it followed the synthetic reference to the enclosing instance — letting an assertion pass on data outside the object being compared. It also could not be satisfied beside an empty collection or an unreachable sibling, reporting a path the caller never wrote.
 - A collection matcher now behaves the same whether the field is named by a path or by a name pattern. `withMatcher(...)` handed the matcher the raw serialised form of a collection-valued field, so `.with("tags", hasSize(2))` passed while `.withMatcher(is("tags"), hasSize(2))` failed on the same field — `iterableWithSize` worked in both, which made the difference look like a matcher quirk rather than an inconsistency.

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/FieldsIgnorerTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/FieldsIgnorerTest.java
@@ -518,8 +518,10 @@ public class FieldsIgnorerTest {
     }
 
     @Test
-    void keepsAnEnvelopeThatChangedWithoutEmptying() {
-        // The envelope loses the ignored field but keeps another, so the envelope itself stays.
+    void removesEveryEnvelopeThatEmpties() {
+        // Named for what it asserts. Each envelope holds only the ignored path, so both empty and
+        // both go; the case its old name described -- an envelope that changes without emptying --
+        // is covered by ignoresPathInEveryEnvelopeWhenNoneEmpties and ignoresPathWhenOnlyOneEnvelopeEmpties.
         JsonObject json = parseObject("{\"0x1\":{\"a\":{\"b\":1}},\"0x2\":{\"a\":{\"b\":2}},\"keep\":9}");
 
         FieldsIgnorer.findPaths(json, paths("a.b"));

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/FieldsIgnorerTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/FieldsIgnorerTest.java
@@ -518,10 +518,26 @@ public class FieldsIgnorerTest {
     }
 
     @Test
+    void keepsAnEnvelopeThatLosesAChildButHasASibling() {
+        // The combination none of the neighbours had: a multi-segment path empties "a", so "a" is
+        // removed from the envelope itself, and the envelope survives on its remaining sibling.
+        // ignoresPathUnderGraphAdapterEnvelopeKey has the envelope-level sibling but removes a leaf;
+        // ignoresPathInEveryEnvelopeWhenNoneEmpties keeps the envelope but removes nothing from it.
+        // This is the branch that reports "a direct key of mine went" and must still not delete the
+        // envelope.
+        JsonObject json = parseObject("{\"0x1\":{\"a\":{\"b\":1},\"other\":2}}");
+
+        FieldsIgnorer.findPaths(json, paths("a.b"));
+
+        assertThat(json.toString(), is("{\"0x1\":{\"other\":2}}"));
+    }
+
+    @Test
     void removesEveryEnvelopeThatEmpties() {
         // Named for what it asserts. Each envelope holds only the ignored path, so both empty and
         // both go; the case its old name described -- an envelope that changes without emptying --
-        // is covered by ignoresPathInEveryEnvelopeWhenNoneEmpties and ignoresPathWhenOnlyOneEnvelopeEmpties.
+        // is covered by ignoresPathInEveryEnvelopeWhenNoneEmpties, ignoresPathWhenOnlyOneEnvelopeEmpties
+        // and keepsAnEnvelopeThatLosesAChildButHasASibling.
         JsonObject json = parseObject("{\"0x1\":{\"a\":{\"b\":1}},\"0x2\":{\"a\":{\"b\":2}},\"keep\":9}");
 
         FieldsIgnorer.findPaths(json, paths("a.b"));

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractBeanMatcherTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/AbstractBeanMatcherTest.java
@@ -1,5 +1,7 @@
 package com.github.karsaig.approvalcrest.matcher;
 
+import com.github.karsaig.approvalcrest.testdata.ChildBean;
+
 import org.junit.jupiter.api.Assertions;
 
 import java.util.function.Consumer;
@@ -44,5 +46,17 @@ public abstract class AbstractBeanMatcherTest extends AbstractTest {
         }
     }
 
+    /**
+     * Holds a single array of ChildBean so array matchers can be exercised on an array field.
+     * Shared by the custom-matcher success and failure suites, which had byte-identical copies.
+     */
+    public static class ArrayHolder {
+        ChildBean[] childBeanArray;
 
+        public ArrayHolder(String first, String second) {
+            childBeanArray = new ChildBean[]{
+                    ChildBean.Builder.child().childString(first).build(),
+                    ChildBean.Builder.child().childString(second).build()};
+        }
+    }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/BeanMatcherCustomFailureTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/BeanMatcherCustomFailureTest.java
@@ -440,13 +440,4 @@ public class BeanMatcherCustomFailureTest extends AbstractBeanMatcherTest {
     }
 
     /** Holds an array of ChildBean so array-specific matcher behaviour can be exercised. */
-    static class ArrayHolder {
-        ChildBean[] childBeanArray;
-
-        ArrayHolder(String first, String second) {
-            childBeanArray = new ChildBean[]{
-                    child().childString(first).build(),
-                    child().childString(second).build()};
-        }
-    }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/BeanMatcherCustomSuccessTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/BeanMatcherCustomSuccessTest.java
@@ -265,7 +265,12 @@ public class BeanMatcherCustomSuccessTest extends AbstractBeanMatcherTest {
     public void matchesIntFieldViaJsonFallback() {
         // Bean path for an int/Integer field returns Integer(0); equalTo(0L) fails because
         // Integer != Long.  The JSON fallback returns Long(0), which passes the matcher.
-        ParentBean expected = parent().childBean(child().childString("apple")).build();
+        //
+        // The two sides differ on the matched field on purpose. Built identically, this test passed
+        // whether the matcher fired or was silently skipped, because the structural comparison
+        // agreed either way. With expected on 7 and actual on 0, only consuming the path lets it
+        // through.
+        ParentBean expected = parent().childBean(child().childString("apple").childInteger(7)).build();
         ParentBean actual = parent().childBean(child().childString("apple")).build();
 
         assertDiagnosingMatcher(actual, expected, beanMatcher -> beanMatcher.with("childBean.childInteger", equalTo(0L)));
@@ -286,8 +291,10 @@ public class BeanMatcherCustomSuccessTest extends AbstractBeanMatcherTest {
     public void matchesDeeplyNestedFieldPath() {
         // 3-level deep path box.item.value is verified by the custom matcher; box.label and name
         // are compared structurally.
+        // The two sides differ on the matched field on purpose: built identically, this passed
+        // whether the matcher fired or was skipped.
         BeanContainer.BeanBox.BeanItem item = new BeanContainer.BeanBox.BeanItem();
-        item.value = "deepValue";
+        item.value = "notTheDeepValue";
         BeanContainer.BeanBox box = new BeanContainer.BeanBox();
         box.label = "box1";
         box.item = item;
@@ -979,14 +986,4 @@ public class BeanMatcherCustomSuccessTest extends AbstractBeanMatcherTest {
         }
     }
 
-    /** Holds a single array of ChildBean so array matchers can be exercised on an array field. */
-    static class ArrayHolder {
-        ChildBean[] childBeanArray;
-
-        ArrayHolder(String first, String second) {
-            childBeanArray = new ChildBean[]{
-                    child().childString(first).build(),
-                    child().childString(second).build()};
-        }
-    }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/JsonMatcherCustomFailureTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/JsonMatcherCustomFailureTest.java
@@ -13,6 +13,9 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -592,11 +595,6 @@ public class JsonMatcherCustomFailureTest extends AbstractJsonMatcherIgnoreTest 
             "  \"parentString\": null\n" +
             "}";
 
-    private static final String APPROVED_WITHOUT_CHILD_BEAN_LIST = "{\n" +
-            "  \"childBean\": null,\n" +
-            "  \"childBeanMap\": [],\n" +
-            "  \"parentString\": null\n" +
-            "}";
 
     /** hasSize reports the actual size on JSON string input, as it does on a bean. */
     @Test
@@ -781,6 +779,67 @@ public class JsonMatcherCustomFailureTest extends AbstractJsonMatcherIgnoreTest 
                 jsonMatcher -> jsonMatcher.with("tags", not(hasSize(2))),
                 error -> Assertions.assertTrue(error.getMessage().contains("tags"),
                         "Expected a tags mismatch, was: " + error.getMessage()),
+                AssertionError.class);
+    }
+
+    // -----------------------------------------------------------------------
+    // Map matchers on JSON-string input: the table's "fails" cells, asserted nowhere until now
+    //
+    // A map serialises to a JsonArray of single-entry objects, so nothing hands a java.util.Map to
+    // the matcher and a Map-typed matcher cannot match. These pin the documented behaviour rather
+    // than endorsing it; the way to assert on a map through a JSON string is to address an entry by
+    // its key.
+    // -----------------------------------------------------------------------
+
+    private static final String MAP_AS_JSON_STRING = "{\n" +
+            "  \"childBean\": null,\n" +
+            "  \"childBeanList\": [],\n" +
+            "  \"childBeanMap\": [\n" +
+            "    {\n" +
+            "      \"key\": {\n" +
+            "        \"childInteger\": 0,\n" +
+            "        \"childString\": \"banana\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"parentString\": null\n" +
+            "}";
+
+    private static final String MAP_AS_JSON_STRING_APPROVED = "{\n" +
+            "  \"childBean\": null,\n" +
+            "  \"childBeanList\": [],\n" +
+            "  \"parentString\": null\n" +
+            "}";
+
+    @Test
+    public void hasKeyFailsOnJsonStringInput() {
+        assertJsonMatcherWithDummyTestInfo(MAP_AS_JSON_STRING, MAP_AS_JSON_STRING_APPROVED,
+                enableExpectedFileSortingWithLenientMatching(),
+                jsonMatcher -> jsonMatcher.with("childBeanMap", hasKey("key")),
+                error -> Assertions.assertTrue(error.getMessage().contains("childBeanMap"),
+                        "Expected a childBeanMap mismatch, was: " + error.getMessage()),
+                AssertionError.class);
+    }
+
+    @Test
+    public void aMapWithSizeFailsOnJsonStringInput() {
+        assertJsonMatcherWithDummyTestInfo(MAP_AS_JSON_STRING, MAP_AS_JSON_STRING_APPROVED,
+                enableExpectedFileSortingWithLenientMatching(),
+                jsonMatcher -> jsonMatcher.with("childBeanMap", aMapWithSize(1)),
+                error -> Assertions.assertTrue(error.getMessage().contains("childBeanMap"),
+                        "Expected a childBeanMap mismatch, was: " + error.getMessage()),
+                AssertionError.class);
+    }
+
+    @Test
+    public void hasEntryFailsOnJsonStringInput() {
+        // Covered for object input already; this is the JSON-string half of the same row.
+        assertJsonMatcherWithDummyTestInfo(MAP_AS_JSON_STRING, MAP_AS_JSON_STRING_APPROVED,
+                enableExpectedFileSortingWithLenientMatching(),
+                jsonMatcher -> jsonMatcher.with("childBeanMap",
+                        hasEntry(equalTo("key"), childStringEqualTo("banana"))),
+                error -> Assertions.assertTrue(error.getMessage().contains("childBeanMap"),
+                        "Expected a childBeanMap mismatch, was: " + error.getMessage()),
                 AssertionError.class);
     }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/JsonMatcherCustomSuccessTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/custom/JsonMatcherCustomSuccessTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
@@ -748,11 +750,6 @@ public class JsonMatcherCustomSuccessTest extends AbstractJsonMatcherIgnoreTest 
         };
     }
 
-    private static final String APPROVED_WITHOUT_CHILD_BEAN_LIST = "{\n" +
-            "  \"childBean\": null,\n" +
-            "  \"childBeanMap\": [],\n" +
-            "  \"parentString\": null\n" +
-            "}";
 
     /**
      * hasSize is typed on Collection. It resolves against the real {@code List<ChildBean>} for an
@@ -1040,5 +1037,56 @@ public class JsonMatcherCustomSuccessTest extends AbstractJsonMatcherIgnoreTest 
                 enableExpectedFileSortingWithLenientMatching(),
                 jsonMatcher -> jsonMatcher.with("childBeanList",
                         not(containsInAnyOrder(childStringEqualTo("apple")))), null);
+    }
+
+    // -----------------------------------------------------------------------
+    // Matchers the compatibility table documents as working, which nothing exercised
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void matchesMapKeyOnObjectInput() {
+        // hasKey is documented and was reachable only through MatcherConfigurationTest, never
+        // through .with(). It works on object input because the map arrives as a java.util.Map.
+        Object input = parent().putToChildBeanMap("key", child().childString("banana")).build();
+        String approvedFileContent = "{\n" +
+                "  \"childBean\": null,\n" +
+                "  \"childBeanList\": [],\n" +
+                "  \"parentString\": null\n" +
+                "}";
+        assertJsonMatcherWithDummyTestInfo(input, approvedFileContent, enableExpectedFileSortingWithLenientMatching(),
+                jsonMatcher -> jsonMatcher.with("childBeanMap", hasKey("key")), null);
+    }
+
+    @Test
+    public void matchesEmptyIterableOnObjectInput() {
+        // emptyIterable is documented as working for both input forms and appeared nowhere.
+        String approvedFileContent = "{\n" +
+                "  \"childBean\": null,\n" +
+                "  \"childBeanMap\": [],\n" +
+                "  \"parentString\": null\n" +
+                "}";
+        assertJsonMatcherWithDummyTestInfo(parent().build(), approvedFileContent,
+                enableExpectedFileSortingWithLenientMatching(),
+                jsonMatcher -> jsonMatcher.with("childBeanList", emptyIterable()), null);
+    }
+
+    @Test
+    public void matchesEmptyIterableOnJsonStringInput() {
+        // The other half of that row: the read-only list view over the JsonArray is an Iterable,
+        // so this holds without the elements needing a class.
+        String input = "{\n" +
+                "  \"childBean\": null,\n" +
+                "  \"childBeanList\": [],\n" +
+                "  \"childBeanMap\": [],\n" +
+                "  \"parentString\": null\n" +
+                "}";
+        String approvedFileContent = "{\n" +
+                "  \"childBean\": null,\n" +
+                "  \"childBeanMap\": [],\n" +
+                "  \"parentString\": null\n" +
+                "}";
+        assertJsonMatcherWithDummyTestInfo(input, approvedFileContent,
+                enableExpectedFileSortingWithLenientMatching(),
+                jsonMatcher -> jsonMatcher.with("childBeanList", emptyIterable()), null);
     }
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/ignores/AbstractJsonMatcherIgnoreTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/ignores/AbstractJsonMatcherIgnoreTest.java
@@ -447,4 +447,15 @@ public abstract class AbstractJsonMatcherIgnoreTest extends AbstractFileMatcherT
             Assertions.assertEquals(expected, thrown.getExpected().getStringRepresentation(), "beanInt shouldn't be present");
         }, AssertionFailedError.class);
     }
+
+    /**
+     * A ParentBean with childBeanList consumed by a custom matcher, so the approved file holds only
+     * the remaining fields. Shared by the custom-matcher success and failure suites, which had
+     * byte-identical copies.
+     */
+    protected static final String APPROVED_WITHOUT_CHILD_BEAN_LIST = "{\n" +
+            "  \"childBean\": null,\n" +
+            "  \"childBeanMap\": [],\n" +
+            "  \"parentString\": null\n" +
+            "}";
 }

--- a/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/sorting/FieldsIgnorerSortingTest.java
+++ b/approvalcrest-core/src/test/java/com/github/karsaig/approvalcrest/matcher/sorting/FieldsIgnorerSortingTest.java
@@ -123,6 +123,53 @@ public class FieldsIgnorerSortingTest {
                 is("[{\"v\":1},{\"v\":2}]"));
     }
 
+    // -------------------------------------------------------------------------
+    // A trailing * is a literal key here too
+    //
+    // The rule is pinned for .ignoring() and ignoringElementsWhere(); for sortField it lived only in
+    // docs/sorting.md, which is the one place a wrong claim would go unnoticed.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void trailingWildcardSortsOnlyTheKeyLiterallyNamedStar() {
+        JsonElement json = parse("{\"map\":{\"*\":[3,1],\"k1\":[3,1]}}");
+
+        FieldsIgnorer.applySorting(json, sortPaths("map.*"), NO_MATCHERS, true);
+
+        // Only the entry keyed "*" is sorted; the sibling keeps the order it was given.
+        assertThat(json.toString(), is("{\"map\":{\"*\":[1,3],\"k1\":[3,1]}}"));
+    }
+
+    @Test
+    void nonFinalWildcardSortsUnderEveryMapValue() {
+        // The contrast on the same shape: with a segment after it, * fans out over every value.
+        JsonElement json = parse("{\"map\":{\"*\":{\"l\":[3,1]},\"k1\":{\"l\":[3,1]}}}");
+
+        FieldsIgnorer.applySorting(json, sortPaths("map.*.l"), NO_MATCHERS, true);
+
+        assertThat(json.toString(), is("{\"map\":{\"*\":{\"l\":[1,3]},\"k1\":{\"l\":[1,3]}}}"));
+    }
+
+    @Test
+    void trailingWildcardWithoutALiteralStarKeySortsNothing() {
+        // The accepted sharp edge: someone writing map.* expecting every value gets a no-op.
+        JsonElement json = parse("{\"map\":{\"k1\":[3,1]}}");
+
+        FieldsIgnorer.applySorting(json, sortPaths("map.*"), NO_MATCHERS, true);
+
+        assertThat(json.toString(), is("{\"map\":{\"k1\":[3,1]}}"));
+    }
+
+    @Test
+    void trailingWildcardSortsALiteralStarKeyInASerialisedMap() {
+        // A real Map serialises to an array of single-entry objects, so cover that shape too.
+        JsonElement json = parse("{\"map\":[{\"*\":[3,1]},{\"k1\":[3,1]}]}");
+
+        FieldsIgnorer.applySorting(json, sortPaths("map.*"), NO_MATCHERS, true);
+
+        assertThat(json.toString(), is("{\"map\":[{\"*\":[1,3]},{\"k1\":[3,1]}]}"));
+    }
+
     @Test
     void applySortingSortsByFieldNameMatcher() {
         JsonElement json = parse("{\"myList\":[{\"v\":2},{\"v\":1}]}");


### PR DESCRIPTION
Test and documentation debt from the review of #43. Test-only, apart from one CHANGELOG heading — no production code changes.

## Documented matchers that nothing exercised

Every claim here was probed before anything was written, and all five matched the compatibility table in `docs/custom-matching.md` — so the documentation was already accurate and merely unasserted.

- **`hasKey`** was documented and reachable only through `MatcherConfigurationTest`, never through `.with()`.
- **`emptyIterable`** is documented as working for both input forms and appeared nowhere in the tree.
- **`hasEntry` and `aMapWithSize`** were covered for object input only, so the table's "fails" cells for JSON-string input were asserted nowhere.

Those cells fail because a `Map` serialises to a `JsonArray` of single-entry objects, so no `java.util.Map` ever reaches a `Map`-typed matcher. The tests pin the documented behaviour rather than endorsing it.

## A trailing `*` on `sortField`

That a final `*` is a literal key rather than a wildcard is pinned for `.ignoring()` and `ignoringElementsWhere()`. For sorting it lived only in `docs/sorting.md`, which is where a wrong claim goes unnoticed longest. Four tests: the literal key sorted while a sibling is left alone, the fan-out contrast on the same fixture, the no-op when no such key exists, and the same in a `Map`'s real serialised form.

Writing these corrected an assumption worth recording: `sortFile` gates **path-driven** sorting, not just object-key sorting. With `sortFile=false` nothing sorts at all, even for a plain named path.

## Two tests that could not fail

`matchesDeeplyNestedFieldPath` and `matchesIntFieldViaJsonFallback` built expected and actual identically, so each passed whether the custom matcher fired or was silently skipped — the structural comparison agreed either way. Each fixture now differs on the matched field, so only consuming the path lets it through. Verified by deleting the `with()` clause and confirming both then fail, naming exactly that field.

## A test that did not test its name

`keepsAnEnvelopeThatChangedWithoutEmptying` → `removesEveryEnvelopeThatEmpties`. Every envelope in its fixture holds only the ignored path, so both empty and both go; its own comment contradicted its name. The case the old name described is covered by `ignoresPathInEveryEnvelopeWhenNoneEmpties` and `ignoresPathWhenOnlyOneEnvelopeEmpties`.

## Tidying

`ArrayHolder` was byte-identical in the bean success and failure suites, and `APPROVED_WITHOUT_CHILD_BEAN_LIST` in the JSON pair; both now live on the shared bases. The CHANGELOG heading reads `Unreleased` rather than trailing a bare dash.

## Verification

`mvn -o clean verify` green on top of `f89ba00`.
